### PR TITLE
Add transform mapping for corporate and natural disq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,15 @@ build:
 	cp ./target/$(artifact_name)-$(version).jar ./$(artifact_name).jar
 
 .PHONY: test
-test: test-unit
+test: test-integration test-unit
 
 .PHONY: test-unit
-test-unit: clean
-	mvn test
+test-unit:
+	mvn test -Dskip.integration.tests=true
+
+.PHONY: test-integration
+test-integration:
+	mvn integration-test -Dskip.unit.tests=true
 
 .PHONY: package
 package:

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <ch-kafka.version>1.4.2</ch-kafka.version>
         <structured-logging.version>1.9.12</structured-logging.version>
         <kafka-models.version>1.0.25</kafka-models.version>
-        <private-api-sdk-java.version>2.0.129</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.133</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
         <skip.integration.tests>false</skip.integration.tests>

--- a/pom.xml
+++ b/pom.xml
@@ -232,14 +232,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit47</artifactId>
-                        <version>${maven-surefire-plugin.version}</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
+                    <argLine>-Dfile.encoding=UTF-8</argLine>
                     <excludes>
                         <exclude>**/*ITest.java</exclude>
                     </excludes>
@@ -259,6 +253,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <argLine>-Dfile.encoding=UTF-8</argLine>
                     <classesDirectory>${project.build.outputDirectory}</classesDirectory>
                     <skipITs>${skip.integration.tests}</skipITs>
                     <includes>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <ch-kafka.version>1.4.2</ch-kafka.version>
         <structured-logging.version>1.9.12</structured-logging.version>
         <kafka-models.version>1.0.25</kafka-models.version>
-        <private-api-sdk-java.version>2.0.133</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.137</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
         <skip.integration.tests>false</skip.integration.tests>

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/DisqualificationMapper.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/DisqualificationMapper.java
@@ -1,0 +1,169 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.mapper;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+import uk.gov.companieshouse.api.delta.Disqualification;
+import uk.gov.companieshouse.api.disqualification.LastVariation;
+
+@Mapper(componentModel = "spring")
+public interface DisqualificationMapper {
+
+    @Mapping(target = "caseIdentifier", source = "courtRef")
+    @Mapping(target = "address", source = "address")
+    @Mapping(target = "companyNames", source = "companyNames")
+    @Mapping(target = "courtName", source = "courtName", ignore = true)
+    @Mapping(target = "disqualificationType", source = "disqType", ignore = true)
+    @Mapping(target = "disqualifiedFrom", source = "disqEffDate", dateFormat = "yyyyMMdd")
+    @Mapping(target = "disqualifiedUntil", source = "disqEndDate", dateFormat = "yyyyMMdd")
+    @Mapping(target = "heardOn", source = "hearingDate", ignore = true)
+    @Mapping(target = "undertakenOn", source = "hearingDate", ignore = true)
+    @Mapping(target = "lastVariation", source = "variationCourt", ignore = true)
+    @Mapping(target = "reason", source = "sectionOfTheAct", ignore = true)
+    uk.gov.companieshouse.api.disqualification.Disqualification map(
+            Disqualification disqualification);
+
+    /**
+    * Invoked at the end of the auto-generated mapping methods.
+    *
+    * @param target     the target disqualification
+    * @param sourceDisq    the source disqualification
+    */
+    @AfterMapping
+    default void parseLastVariation(
+                @MappingTarget uk.gov.companieshouse.api.disqualification.Disqualification target,
+                Disqualification sourceDisq) {
+        if (sourceDisq.getVarInstrumentStartDate() == null
+                || sourceDisq.getVarInstrumentStartDate().equals("")) {
+            return;
+        }
+        LastVariation lastVariation = new LastVariation(); 
+        DateTimeFormatter formater = DateTimeFormatter.ofPattern("yyyyMMdd");
+        LocalDate varDate = LocalDate.parse(sourceDisq.getVarInstrumentStartDate(), formater);
+        lastVariation.setVariedOn(varDate);
+        lastVariation.setCaseIdentifier(sourceDisq.getVariationCourtRefNo());
+        lastVariation.setCourtName(sourceDisq.getVariationCourt());
+        
+        List<LastVariation> lastVarList = new ArrayList<>();
+        lastVarList.add(lastVariation);
+        target.setLastVariation(lastVarList);
+    }
+
+    /**
+    * Invoked at the end of the auto-generated mapping methods.
+    *
+    * @param target     the target disqualification
+    * @param sourceDisq    the source disqualification
+    */
+    @AfterMapping
+    default void parseReason(
+                @MappingTarget uk.gov.companieshouse.api.disqualification.Disqualification target,
+                Disqualification sourceDisq) {
+
+        HashMap<String, String> disqualifyingLaw = new HashMap<>();
+        disqualifyingLaw.put("CDDA", "company-directors-disqualification-act-1986");
+        disqualifyingLaw.put("CDDO",
+                "company-directors-disqualification-northern-ireland-order-2002");
+
+        HashMap<String, String> descriptionIdentifier = new HashMap<>();
+        descriptionIdentifier.put("A5", "conviction-of-offence-punishable-on-"
+                + "indictment-or-conviction-on-indictment-or-summary-conviction");
+        descriptionIdentifier.put("A6", "persistent-default-under-companies-legislation");
+        descriptionIdentifier.put("A7", "fraud-etc-in-winding-up");
+        descriptionIdentifier.put("A8", "summary-conviction-of-offence");
+        descriptionIdentifier.put("A8A", "certain-convictions-abroad");
+        descriptionIdentifier.put("A9", 
+                "high-court-to-disqualify-unfit-directors-of-insolvent-companies");
+        descriptionIdentifier.put("A10", "order-or-undertaking-and-reporting-provisions");
+        descriptionIdentifier.put("A11", 
+                "investigation-of-company");
+        descriptionIdentifier.put("A11A", "order-disqualifying-a-"
+                + "person-instructing-an-unfit-director-of-an-insolvent-company");
+        descriptionIdentifier.put("A11C", "undertaking-instead-of-order-under-article-11a");
+        descriptionIdentifier.put("A11D", 
+                "order-disqualifying-a-person-instructing-an-unfit-director");
+        descriptionIdentifier.put("A11E", "undertaking-instead-of-order-under-article-11d");
+        descriptionIdentifier.put("A13A", 
+                "competition-and-markets-authority-disqualification-order");
+        descriptionIdentifier.put("A13B", 
+                "competition-and-markets-authority-disqualification-undertaking");
+        descriptionIdentifier.put("A14", "participation-in-wrongful-trading");
+        descriptionIdentifier.put("S2", "conviction-of-indictable-offence");
+        descriptionIdentifier.put("S3", "persistent-breaches-of-companies-legislation");
+        descriptionIdentifier.put("S4", "fraud-etc-in-winding-up");
+        descriptionIdentifier.put("S5", "summary-conviction");
+        descriptionIdentifier.put("S5A", "certain-convictions-abroad");
+        descriptionIdentifier.put("S6", 
+                "court-to-disqualify-unfit-directors-of-insolvent-companies");
+        descriptionIdentifier.put("S7", "order-or-undertaking-and-reporting-provisions");
+        descriptionIdentifier.put("S8", "investigation-of-company");
+        descriptionIdentifier.put("S8ZA", "order-disqualifying-a-person"
+                + "-instructing-an-unfit-director-of-an-insolvent-company");
+        descriptionIdentifier.put("S8ZC", "undertaking-disqualifying-a-person"
+                + "-instructing-an-unfit-director-of-an-insolvent-company");
+        descriptionIdentifier.put("S8ZD", 
+                "order-disqualifying-a-person-instructing-an-unfit-director");
+        descriptionIdentifier.put("S8ZE", 
+                "undertaking-disqualifying-a-person-instructing-an-unfit-director");
+        descriptionIdentifier.put("S9", "matters-determining-unfitness-of-directors");
+        descriptionIdentifier.put("S9A", 
+                "competition-and-markets-authority-disqualification-order");
+        descriptionIdentifier.put("S9B", 
+                "competition-and-markets-authority-disqualification-undertaking");
+        descriptionIdentifier.put("S10", "participation-in-wrongful-trading");
+
+        String[] sectionParts = sourceDisq.getSectionOfTheAct().split(" ");
+        HashMap<String, String> reason = new HashMap<>();
+        reason.put("act", disqualifyingLaw.get(sectionParts[0]));
+        reason.put("description_identifier", descriptionIdentifier.get(sectionParts[2]));
+
+        String disqualificationReference = sectionParts[0].equals("CDDA") ? "section" : "article";
+
+        reason.put(disqualificationReference, sectionParts[2].substring(1));
+
+        target.setReason(reason);
+    }
+
+    /**
+    * Invoked at the end of the auto-generated mapping methods.
+    *
+    * @param target     the target disqualification
+    * @param sourceDisq    the source disqualification
+    */
+    @AfterMapping
+    default void parseDisqType(
+                @MappingTarget uk.gov.companieshouse.api.disqualification.Disqualification target,
+                Disqualification sourceDisq) {
+        HashMap<String, String> disqualificationType = new HashMap<>();
+        disqualificationType.put("ORDER", "court-order");
+        disqualificationType.put("UNDERTAKING", "undertaking");
+        target.setDisqualificationType(disqualificationType.get(sourceDisq.getDisqType()));
+    }
+
+    /**
+    * Invoked at the end of the auto-generated mapping methods.
+    *
+    * @param target     the target disqualification
+    * @param sourceDisq    the source disqualification
+    */
+    @AfterMapping
+    default void parseHearingDetails(
+                @MappingTarget uk.gov.companieshouse.api.disqualification.Disqualification target,
+                Disqualification sourceDisq) {
+        DateTimeFormatter formater = DateTimeFormatter.ofPattern("yyyyMMdd");
+        if (sourceDisq.getDisqType().equals("ORDER")) {
+            target.setCourtName(sourceDisq.getCourtName());
+            target.setHeardOn(LocalDate.parse(sourceDisq.getHearingDate(), formater));
+        } else {
+            target.setUndertakenOn(LocalDate.parse(sourceDisq.getHearingDate(), formater));
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/DisqualificationMapper.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/DisqualificationMapper.java
@@ -73,52 +73,7 @@ public interface DisqualificationMapper {
         disqualifyingLaw.put("CDDO",
                 "company-directors-disqualification-northern-ireland-order-2002");
 
-        HashMap<String, String> descriptionIdentifier = new HashMap<>();
-        descriptionIdentifier.put("A5", "conviction-of-offence-punishable-on-"
-                + "indictment-or-conviction-on-indictment-or-summary-conviction");
-        descriptionIdentifier.put("A6", "persistent-default-under-companies-legislation");
-        descriptionIdentifier.put("A7", "fraud-etc-in-winding-up");
-        descriptionIdentifier.put("A8", "summary-conviction-of-offence");
-        descriptionIdentifier.put("A8A", "certain-convictions-abroad");
-        descriptionIdentifier.put("A9", 
-                "high-court-to-disqualify-unfit-directors-of-insolvent-companies");
-        descriptionIdentifier.put("A10", "order-or-undertaking-and-reporting-provisions");
-        descriptionIdentifier.put("A11", 
-                "investigation-of-company");
-        descriptionIdentifier.put("A11A", "order-disqualifying-a-"
-                + "person-instructing-an-unfit-director-of-an-insolvent-company");
-        descriptionIdentifier.put("A11C", "undertaking-instead-of-order-under-article-11a");
-        descriptionIdentifier.put("A11D", 
-                "order-disqualifying-a-person-instructing-an-unfit-director");
-        descriptionIdentifier.put("A11E", "undertaking-instead-of-order-under-article-11d");
-        descriptionIdentifier.put("A13A", 
-                "competition-and-markets-authority-disqualification-order");
-        descriptionIdentifier.put("A13B", 
-                "competition-and-markets-authority-disqualification-undertaking");
-        descriptionIdentifier.put("A14", "participation-in-wrongful-trading");
-        descriptionIdentifier.put("S2", "conviction-of-indictable-offence");
-        descriptionIdentifier.put("S3", "persistent-breaches-of-companies-legislation");
-        descriptionIdentifier.put("S4", "fraud-etc-in-winding-up");
-        descriptionIdentifier.put("S5", "summary-conviction");
-        descriptionIdentifier.put("S5A", "certain-convictions-abroad");
-        descriptionIdentifier.put("S6", 
-                "court-to-disqualify-unfit-directors-of-insolvent-companies");
-        descriptionIdentifier.put("S7", "order-or-undertaking-and-reporting-provisions");
-        descriptionIdentifier.put("S8", "investigation-of-company");
-        descriptionIdentifier.put("S8ZA", "order-disqualifying-a-person"
-                + "-instructing-an-unfit-director-of-an-insolvent-company");
-        descriptionIdentifier.put("S8ZC", "undertaking-disqualifying-a-person"
-                + "-instructing-an-unfit-director-of-an-insolvent-company");
-        descriptionIdentifier.put("S8ZD", 
-                "order-disqualifying-a-person-instructing-an-unfit-director");
-        descriptionIdentifier.put("S8ZE", 
-                "undertaking-disqualifying-a-person-instructing-an-unfit-director");
-        descriptionIdentifier.put("S9", "matters-determining-unfitness-of-directors");
-        descriptionIdentifier.put("S9A", 
-                "competition-and-markets-authority-disqualification-order");
-        descriptionIdentifier.put("S9B", 
-                "competition-and-markets-authority-disqualification-undertaking");
-        descriptionIdentifier.put("S10", "participation-in-wrongful-trading");
+        HashMap<String, String> descriptionIdentifier = MapperUtils.createIdentifierHashMap();
 
         String[] sectionParts = sourceDisq.getSectionOfTheAct().split(" ");
         HashMap<String, String> reason = new HashMap<>();

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalCorporateDisqualificationMapper.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalCorporateDisqualificationMapper.java
@@ -1,24 +1,47 @@
 package uk.gov.companieshouse.disqualifiedofficers.delta.mapper;
 
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 
 import uk.gov.companieshouse.api.delta.DisqualificationOfficer;
+import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.InternalDisqualificationApiInternalData;
 
 
 @Mapper(componentModel = "spring", uses = {DisqualificationMapper.class, 
         PermissionToActMapper.class})
 public interface InternalCorporateDisqualificationMapper {
 
-    @Mapping(target = "externalData.officerDisqId", source = "officerDisqId")
+    @Mapping(target = "internalData.officerDisqId", source = "officerDisqId")
+    @Mapping(target = "internalData.officerDetailId", source = "officerDetailId")
+    @Mapping(target = "internalData.officerIdRaw", source = "officerId")
     @Mapping(target = "externalData.companyNumber", source = "registeredNumber")
-    @Mapping(target = "externalData.officerDetailId", source = "officerDetailId")
+    @Mapping(target = "externalData.personNumber", source = "externalNumber")
     @Mapping(target = "externalData.countryOfRegistration", source = "registeredLocation")
     @Mapping(target = "externalData.name", source = "surname")
     @Mapping(target = "externalData.disqualifications", source = "disqualifications")
     @Mapping(target = "externalData.permissionsToAct", source = "exemptions")
     InternalCorporateDisqualificationApi disqualificationDeltaToApi(
             DisqualificationOfficer disqualificationOfficer);
+
+    /**
+    * Invoked at the end of the auto-generated mapping methods.
+    * @param target        the target object
+    * @param sourceCase    the source object
+    */
+    @AfterMapping
+    default void mapLinksAndId(@MappingTarget InternalCorporateDisqualificationApi target,
+                                  DisqualificationOfficer sourceCase) {
+        
+        String encodedOfficerId = MapperUtils.encode(sourceCase.getOfficerId());
+        String link = String.format("/disqualifiedofficer/corporate/%s", encodedOfficerId);
+        CorporateDisqualificationApi externalTarget = target.getExternalData();
+        InternalDisqualificationApiInternalData internalData = target.getInternalData();
+        externalTarget.setLinks(link);
+        internalData.setOfficerId(encodedOfficerId);
+    }
 
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalCorporateDisqualificationMapper.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalCorporateDisqualificationMapper.java
@@ -1,0 +1,24 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import uk.gov.companieshouse.api.delta.DisqualificationOfficer;
+import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
+
+
+@Mapper(componentModel = "spring", uses = {DisqualificationMapper.class, 
+        PermissionToActMapper.class})
+public interface InternalCorporateDisqualificationMapper {
+
+    @Mapping(target = "externalData.officerDisqId", source = "officerDisqId")
+    @Mapping(target = "externalData.companyNumber", source = "registeredNumber")
+    @Mapping(target = "externalData.officerDetailId", source = "officerDetailId")
+    @Mapping(target = "externalData.countryOfRegistration", source = "registeredLocation")
+    @Mapping(target = "externalData.name", source = "surname")
+    @Mapping(target = "externalData.disqualifications", source = "disqualifications")
+    @Mapping(target = "externalData.permissionsToAct", source = "exemptions")
+    InternalCorporateDisqualificationApi disqualificationDeltaToApi(
+            DisqualificationOfficer disqualificationOfficer);
+
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalNaturalDisqualificationMapper.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalNaturalDisqualificationMapper.java
@@ -1,19 +1,24 @@
 package uk.gov.companieshouse.disqualifiedofficers.delta.mapper;
 
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 
 import uk.gov.companieshouse.api.delta.DisqualificationOfficer;
+import uk.gov.companieshouse.api.disqualification.InternalDisqualificationApiInternalData;
 import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
 
 @Mapper(componentModel = "spring", uses = {DisqualificationMapper.class, 
         PermissionToActMapper.class})
 public interface InternalNaturalDisqualificationMapper {
 
+    @Mapping(target = "internalData.officerDisqId", source = "officerDisqId")
+    @Mapping(target = "internalData.officerDetailId", source = "officerDetailId")
+    @Mapping(target = "internalData.officerIdRaw", source = "officerId")
     @Mapping(target = "externalData.dateOfBirth", source = "dateOfBirth", dateFormat = "yyyyMMdd")
-    @Mapping(target = "externalData.officerDisqId", source = "officerDisqId")
     @Mapping(target = "externalData.personNumber", source = "externalNumber")
-    @Mapping(target = "externalData.officerDetailId", source = "officerDetailId")
     @Mapping(target = "externalData.forename", source = "forename")
     @Mapping(target = "externalData.honours", source = "honours")
     @Mapping(target = "externalData.nationality", source = "nationality")
@@ -24,5 +29,22 @@ public interface InternalNaturalDisqualificationMapper {
     @Mapping(target = "externalData.permissionsToAct", source = "exemptions")
     InternalNaturalDisqualificationApi disqualificationDeltaToApi(
             DisqualificationOfficer disqualificationOfficer);
+
+    /**
+    * Invoked at the end of the auto-generated mapping methods.
+    * @param target        the target object
+    * @param sourceCase    the source object
+    */
+    @AfterMapping
+    default void mapLinksAndId(@MappingTarget InternalNaturalDisqualificationApi target,
+                                  DisqualificationOfficer sourceCase) {
+        
+        String encodedOfficerId = MapperUtils.encode(sourceCase.getOfficerId());
+        String link = String.format("/disqualifiedofficer/natural/%s", encodedOfficerId);
+        NaturalDisqualificationApi externalTarget = target.getExternalData();
+        InternalDisqualificationApiInternalData internalData = target.getInternalData();
+        externalTarget.setLinks(link);
+        internalData.setOfficerId(encodedOfficerId);
+    }
 
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalNaturalDisqualificationMapper.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalNaturalDisqualificationMapper.java
@@ -1,0 +1,28 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import uk.gov.companieshouse.api.delta.DisqualificationOfficer;
+import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
+
+@Mapper(componentModel = "spring", uses = {DisqualificationMapper.class, 
+        PermissionToActMapper.class})
+public interface InternalNaturalDisqualificationMapper {
+
+    @Mapping(target = "externalData.dateOfBirth", source = "dateOfBirth", dateFormat = "yyyyMMdd")
+    @Mapping(target = "externalData.officerDisqId", source = "officerDisqId")
+    @Mapping(target = "externalData.personNumber", source = "externalNumber")
+    @Mapping(target = "externalData.officerDetailId", source = "officerDetailId")
+    @Mapping(target = "externalData.forename", source = "forename")
+    @Mapping(target = "externalData.honours", source = "honours")
+    @Mapping(target = "externalData.nationality", source = "nationality")
+    @Mapping(target = "externalData.surname", source = "surname")
+    @Mapping(target = "externalData.title", source = "title")
+    @Mapping(target = "externalData.otherForenames", source = "middleName")
+    @Mapping(target = "externalData.disqualifications", source = "disqualifications")
+    @Mapping(target = "externalData.permissionsToAct", source = "exemptions")
+    InternalNaturalDisqualificationApi disqualificationDeltaToApi(
+            DisqualificationOfficer disqualificationOfficer);
+
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/MapperUtils.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/MapperUtils.java
@@ -21,6 +21,10 @@ public final class MapperUtils {
         return encodedOfficerId;
     }
     
+    /**
+     * Create a map of values to lookup using description identifier.
+     * @return the hashmap of description identifiers to descriptions
+     */
     public static HashMap<String, String> createIdentifierHashMap() {
 
         HashMap<String, String> descriptionIdentifier = new HashMap<>();

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/MapperUtils.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/MapperUtils.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.disqualifiedofficers.delta.mapper;
 
 import java.util.Base64;
+import java.util.HashMap;
 
 import org.apache.commons.codec.digest.DigestUtils;
 
@@ -20,4 +21,55 @@ public final class MapperUtils {
         return encodedOfficerId;
     }
     
+    public static HashMap<String, String> createIdentifierHashMap() {
+
+        HashMap<String, String> descriptionIdentifier = new HashMap<>();
+        descriptionIdentifier.put("A5", "conviction-of-offence-punishable-on-"
+                + "indictment-or-conviction-on-indictment-or-summary-conviction");
+        descriptionIdentifier.put("A6", "persistent-default-under-companies-legislation");
+        descriptionIdentifier.put("A7", "fraud-etc-in-winding-up");
+        descriptionIdentifier.put("A8", "summary-conviction-of-offence");
+        descriptionIdentifier.put("A8A", "certain-convictions-abroad");
+        descriptionIdentifier.put("A9", 
+                "high-court-to-disqualify-unfit-directors-of-insolvent-companies");
+        descriptionIdentifier.put("A10", "order-or-undertaking-and-reporting-provisions");
+        descriptionIdentifier.put("A11", 
+                "investigation-of-company");
+        descriptionIdentifier.put("A11A", "order-disqualifying-a-"
+                + "person-instructing-an-unfit-director-of-an-insolvent-company");
+        descriptionIdentifier.put("A11C", "undertaking-instead-of-order-under-article-11a");
+        descriptionIdentifier.put("A11D", 
+                "order-disqualifying-a-person-instructing-an-unfit-director");
+        descriptionIdentifier.put("A11E", "undertaking-instead-of-order-under-article-11d");
+        descriptionIdentifier.put("A13A", 
+                "competition-and-markets-authority-disqualification-order");
+        descriptionIdentifier.put("A13B", 
+                "competition-and-markets-authority-disqualification-undertaking");
+        descriptionIdentifier.put("A14", "participation-in-wrongful-trading");
+        descriptionIdentifier.put("S2", "conviction-of-indictable-offence");
+        descriptionIdentifier.put("S3", "persistent-breaches-of-companies-legislation");
+        descriptionIdentifier.put("S4", "fraud-etc-in-winding-up");
+        descriptionIdentifier.put("S5", "summary-conviction");
+        descriptionIdentifier.put("S5A", "certain-convictions-abroad");
+        descriptionIdentifier.put("S6", 
+                "court-to-disqualify-unfit-directors-of-insolvent-companies");
+        descriptionIdentifier.put("S7", "order-or-undertaking-and-reporting-provisions");
+        descriptionIdentifier.put("S8", "investigation-of-company");
+        descriptionIdentifier.put("S8ZA", "order-disqualifying-a-person"
+                + "-instructing-an-unfit-director-of-an-insolvent-company");
+        descriptionIdentifier.put("S8ZC", "undertaking-disqualifying-a-person"
+                + "-instructing-an-unfit-director-of-an-insolvent-company");
+        descriptionIdentifier.put("S8ZD", 
+                "order-disqualifying-a-person-instructing-an-unfit-director");
+        descriptionIdentifier.put("S8ZE", 
+                "undertaking-disqualifying-a-person-instructing-an-unfit-director");
+        descriptionIdentifier.put("S9", "matters-determining-unfitness-of-directors");
+        descriptionIdentifier.put("S9A", 
+                "competition-and-markets-authority-disqualification-order");
+        descriptionIdentifier.put("S9B", 
+                "competition-and-markets-authority-disqualification-undertaking");
+        descriptionIdentifier.put("S10", "participation-in-wrongful-trading");
+
+        return descriptionIdentifier;
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/MapperUtils.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/MapperUtils.java
@@ -1,0 +1,23 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.mapper;
+
+import java.util.Base64;
+
+import org.apache.commons.codec.digest.DigestUtils;
+
+public final class MapperUtils {
+
+    // make the class noninstantiable
+    private MapperUtils() {
+    }
+
+    /**
+     * encode the officerId for use in links and id.
+     */
+    public static String encode(String officerId) {
+        String salt = "my2_4s!gdDxC4$n9";
+        String encodedOfficerId = Base64.getUrlEncoder().withoutPadding().encodeToString(
+                DigestUtils.sha1(officerId + salt));
+        return encodedOfficerId;
+    }
+    
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/PermissionToActMapper.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/PermissionToActMapper.java
@@ -1,0 +1,21 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import uk.gov.companieshouse.api.delta.Exemption;
+import uk.gov.companieshouse.api.disqualification.PermissionToAct;
+
+
+@Mapper(componentModel = "spring")
+public interface PermissionToActMapper {
+
+    @Mapping(target = "companyNames", source = "companyNames")
+    @Mapping(target = "courtName", source = "courtName")
+    @Mapping(target = "expiresOn", source = "expiresOn", dateFormat = "yyyyMMdd")
+    @Mapping(target = "grantedOn", source = "grantedOn", dateFormat = "yyyyMMdd")
+    @Mapping(target = "purpose", source = "purpose")
+    PermissionToAct disqualificationDeltaToApi(
+            Exemption exemptions);
+
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/transformer/DisqualifiedOfficersApiTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/transformer/DisqualifiedOfficersApiTransformer.java
@@ -81,7 +81,7 @@ public class DisqualifiedOfficersApiTransformer {
 
     /**
     * Maps the delta at which is not passed into the mapper.
-    * @param apiObject the InternalNaturalDisqualificationApi object from the mapper.
+    * @param apiObject the InternalCorporateDisqualificationApi object from the mapper.
     * @param disqualificationDelta the delta from CHIPS containing the delta_at
     * @return the original api object with the delta_at parsed.
     */

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/transformer/DisqualifiedOfficersApiTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/transformer/DisqualifiedOfficersApiTransformer.java
@@ -9,9 +9,8 @@ import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.delta.DisqualificationDelta;
 import uk.gov.companieshouse.api.delta.DisqualificationOfficer;
 import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
-import uk.gov.companieshouse.api.disqualification.InternalData;
+import uk.gov.companieshouse.api.disqualification.InternalDisqualificationApiInternalData;
 import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
-import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApiInternalData;
 import uk.gov.companieshouse.disqualifiedofficers.delta.mapper.InternalCorporateDisqualificationMapper;
 import uk.gov.companieshouse.disqualifiedofficers.delta.mapper.InternalNaturalDisqualificationMapper;
 
@@ -70,8 +69,7 @@ public class DisqualifiedOfficersApiTransformer {
     private InternalNaturalDisqualificationApi parseNaturalDeltaAt(
             InternalNaturalDisqualificationApi apiObject,
             DisqualificationDelta disqualificationDelta) {
-        InternalNaturalDisqualificationApiInternalData internalData = new
-                InternalNaturalDisqualificationApiInternalData();
+        InternalDisqualificationApiInternalData internalData = apiObject.getInternalData();
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSSSSS")
                 .withZone(ZoneId.of("Z"));
         ZonedDateTime datetime = ZonedDateTime.parse(disqualificationDelta.getDeltaAt(), formatter);
@@ -90,7 +88,7 @@ public class DisqualifiedOfficersApiTransformer {
     private InternalCorporateDisqualificationApi parseCorporateDeltaAt(
             InternalCorporateDisqualificationApi apiObject,
             DisqualificationDelta disqualificationDelta) {
-        InternalData internalData = new InternalData();
+        InternalDisqualificationApiInternalData internalData = apiObject.getInternalData();
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSSSSS")
                 .withZone(ZoneId.of("Z"));
         ZonedDateTime datetime = ZonedDateTime.parse(disqualificationDelta.getDeltaAt(), formatter);

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/transformer/DisqualifiedOfficersApiTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/transformer/DisqualifiedOfficersApiTransformer.java
@@ -1,13 +1,102 @@
 package uk.gov.companieshouse.disqualifiedofficers.delta.transformer;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.delta.DisqualificationDelta;
+import uk.gov.companieshouse.api.delta.DisqualificationOfficer;
+import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.InternalData;
+import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApiInternalData;
+import uk.gov.companieshouse.disqualifiedofficers.delta.mapper.InternalCorporateDisqualificationMapper;
+import uk.gov.companieshouse.disqualifiedofficers.delta.mapper.InternalNaturalDisqualificationMapper;
 
 @Component
 public class DisqualifiedOfficersApiTransformer {
 
-    public String transform(DisqualificationDelta disqualifiedOfficersDelta) {
-        // TODO: Use mapStruct to transform json object to Open API generated object
-        return disqualifiedOfficersDelta.toString();
+    private final InternalCorporateDisqualificationMapper corporateMapper;
+    private final InternalNaturalDisqualificationMapper naturalMapper;
+
+    /**
+     * Constructor for the transformer.
+     * @param corporateMapper returns the corporate disqualification api object.
+     * @param naturalMapper returns the natural disqualification api object.
+     */
+    @Autowired
+    public DisqualifiedOfficersApiTransformer(
+            InternalCorporateDisqualificationMapper corporateMapper, 
+            InternalNaturalDisqualificationMapper naturalMapper
+    ) {
+        this.naturalMapper = naturalMapper;
+        this.corporateMapper = corporateMapper;
+    }
+
+    /**
+    * Maps the natural disqualification delta to an api object.
+    * @param disqualificationDelta the CHIPS delta
+    * @return the InternalNaturalDisqualificationApi object
+    */
+    public InternalNaturalDisqualificationApi transformNaturalDisqualification(
+            DisqualificationDelta disqualificationDelta) {
+        DisqualificationOfficer officer = disqualificationDelta.getDisqualifiedOfficer().get(0);
+        InternalNaturalDisqualificationApi apiObject = naturalMapper
+                        .disqualificationDeltaToApi(officer);
+        return parseNaturalDeltaAt(apiObject, disqualificationDelta);
+    }
+
+    /**
+    * Maps the corporate disqualification delta to an api object.
+    * @param disqualificationDelta the CHIPS delta
+    * @return the InternalCorporateDisqualificationApi object
+    */
+    public InternalCorporateDisqualificationApi transformCorporateDisqualification(
+            DisqualificationDelta disqualificationDelta) {
+        DisqualificationOfficer officer = disqualificationDelta.getDisqualifiedOfficer().get(0);
+        InternalCorporateDisqualificationApi abiObject = corporateMapper
+                        .disqualificationDeltaToApi(officer);
+        return parseCorporateDeltaAt(abiObject, disqualificationDelta);
+    }
+
+    /**
+     * Maps the delta at which is not passed into the mapper.
+     * @param apiObject the InternalNaturalDisqualificationApi object from the mapper.
+     * @param disqualificationDelta the delta from CHIPS containing the delta_at
+     * @return the original api object with the delta_at parsed.
+     */
+    private InternalNaturalDisqualificationApi parseNaturalDeltaAt(
+            InternalNaturalDisqualificationApi apiObject,
+            DisqualificationDelta disqualificationDelta) {
+        InternalNaturalDisqualificationApiInternalData internalData = new
+                InternalNaturalDisqualificationApiInternalData();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSSSSS")
+                .withZone(ZoneId.of("Z"));
+        ZonedDateTime datetime = ZonedDateTime.parse(disqualificationDelta.getDeltaAt(), formatter);
+        internalData.setDeltaAt(datetime.toOffsetDateTime());
+        
+        apiObject.setInternalData(internalData);
+        return apiObject;
+    }
+
+    /**
+    * Maps the delta at which is not passed into the mapper.
+    * @param apiObject the InternalNaturalDisqualificationApi object from the mapper.
+    * @param disqualificationDelta the delta from CHIPS containing the delta_at
+    * @return the original api object with the delta_at parsed.
+    */
+    private InternalCorporateDisqualificationApi parseCorporateDeltaAt(
+            InternalCorporateDisqualificationApi apiObject,
+            DisqualificationDelta disqualificationDelta) {
+        InternalData internalData = new InternalData();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSSSSS")
+                .withZone(ZoneId.of("Z"));
+        ZonedDateTime datetime = ZonedDateTime.parse(disqualificationDelta.getDeltaAt(), formatter);
+        internalData.setDeltaAt(datetime.toOffsetDateTime());
+        
+        apiObject.setInternalData(internalData);
+        return apiObject;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalCorporateDisqualificationMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalCorporateDisqualificationMapperTest.java
@@ -88,7 +88,6 @@ class InternalCorporateDisqualificationMapperTest {
         assertEquals(externalDisqualificationTarget.getCountryOfRegistration(), "England");
 
         Disqualification disqualification = externalDisqualificationTarget.getDisqualifications().get(0);
-        System.out.println(externalDisqualificationTarget);
         assertEquals(disqualification.getCaseIdentifier(), "IME3707935");
         List<String> list = new ArrayList<>();
         list.add("TEEHEE LIMITED");

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalCorporateDisqualificationMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalCorporateDisqualificationMapperTest.java
@@ -1,0 +1,105 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.mapper;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.util.FileCopyUtils;
+
+import uk.gov.companieshouse.api.delta.DisqualificationDelta;
+import uk.gov.companieshouse.api.delta.DisqualificationOfficer;
+import uk.gov.companieshouse.api.disqualification.Disqualification;
+import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.LastVariation;
+import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.PermissionToAct;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {
+        InternalCorporateDisqualificationMapperImpl.class,
+        DisqualificationMapperImpl.class,
+        PermissionToActMapperImpl.class})
+class InternalCorporateDisqualificationMapperTest {
+
+    private ObjectMapper mapper;
+    private DisqualificationDelta disqualificationDelta;
+    private DisqualificationOfficer disqualificationOfficer;
+
+    @Autowired
+    InternalCorporateDisqualificationMapper disqualificationMapper;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        mapper = new ObjectMapper();
+
+        String path = "disqualified-officers-corporate-example.json";
+        String input =
+                FileCopyUtils.copyToString(new InputStreamReader(ClassLoader.getSystemClassLoader().getResourceAsStream(path)));
+
+        disqualificationDelta = mapper.readValue(input, DisqualificationDelta.class);
+        disqualificationOfficer = disqualificationDelta.getDisqualifiedOfficer().get(0);
+    }
+
+    @Test
+    void shouldMapDisqualificationOfficerToCorporateDisqualification() {
+        InternalCorporateDisqualificationApi disqualificationTarget =
+        disqualificationMapper.disqualificationDeltaToApi(disqualificationOfficer);
+        CorporateDisqualificationApi externalDisqualificationTarget = disqualificationTarget.getExternalData();
+
+        PermissionToAct permissionToAct = new PermissionToAct();
+        List<String> companyNames = new ArrayList<>();
+        companyNames.add("TEST1 LTD");
+        companyNames.add("TEST LTD");
+        permissionToAct.setCompanyNames(companyNames);
+        permissionToAct.setCourtName("CARDIFF");
+        permissionToAct.setExpiresOn(LocalDate.of(2015, 02, 23));
+        permissionToAct.setGrantedOn(LocalDate.of(2013, 05, 15));
+
+        assertThat(disqualificationDelta).isNotNull();
+        assertThat(disqualificationTarget).isNotNull();
+        assertEquals(externalDisqualificationTarget.getName(), "BOOMSHACK LTD.");
+        assertEquals(externalDisqualificationTarget.getOfficerDetailId(), null);
+        assertEquals(externalDisqualificationTarget.getOfficerDisqId(), null);
+        assertEquals(externalDisqualificationTarget.getPersonNumber(), null);
+        assertEquals(externalDisqualificationTarget.getPermissionsToAct().get(0), permissionToAct);
+
+        Disqualification disqualification = externalDisqualificationTarget.getDisqualifications().get(0);
+        System.out.println(externalDisqualificationTarget);
+        assertEquals(disqualification.getCaseIdentifier(), "IME3707935");
+        List<String> list = new ArrayList<>();
+        list.add("TEEHEE LIMITED");
+        list.add("HOOHAH LIMITED");
+        assertEquals(disqualification.getCompanyNames(), list);
+        assertEquals(disqualification.getCourtName(), "UNDERTAKING");
+        LastVariation var = new LastVariation();
+        var.setVariedOn(LocalDate.of(2015, 11, 17));
+        var.setCaseIdentifier("VARY DQ01 EFF DATE TO CURRENT");
+        var.setCourtName("CHDBALDWIN");
+        assertEquals(var, disqualification.getLastVariation().get(0));
+        assertEquals(disqualification.getDisqualificationType(), "court-order");
+        HashMap<String, String> reason = new HashMap<>();
+        reason.put("act", "company-directors-disqualification-northern-ireland-order-2002");
+        reason.put("article", "4");
+        reason.put("description_identifier", "fraud-etc-in-winding-up");
+        assertEquals(disqualification.getReason(), reason);
+        assertEquals(disqualification.getHeardOn(), LocalDate.of(2013, 01, 01));
+        assertNull(disqualification.getUndertakenOn());
+        assertEquals(disqualification.getDisqualifiedFrom(), LocalDate.of(2013, 06, 24));
+        assertEquals(disqualification.getDisqualifiedUntil(), LocalDate.of(2018, 06, 23));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalCorporateDisqualificationMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalCorporateDisqualificationMapperTest.java
@@ -21,6 +21,7 @@ import uk.gov.companieshouse.api.delta.DisqualificationDelta;
 import uk.gov.companieshouse.api.delta.DisqualificationOfficer;
 import uk.gov.companieshouse.api.disqualification.Disqualification;
 import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.InternalDisqualificationApiInternalData;
 import uk.gov.companieshouse.api.disqualification.LastVariation;
 import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.PermissionToAct;
@@ -60,6 +61,8 @@ class InternalCorporateDisqualificationMapperTest {
         InternalCorporateDisqualificationApi disqualificationTarget =
         disqualificationMapper.disqualificationDeltaToApi(disqualificationOfficer);
         CorporateDisqualificationApi externalDisqualificationTarget = disqualificationTarget.getExternalData();
+        InternalDisqualificationApiInternalData internalDisqualificationTarget = disqualificationTarget
+                .getInternalData();
 
         PermissionToAct permissionToAct = new PermissionToAct();
         List<String> companyNames = new ArrayList<>();
@@ -73,10 +76,16 @@ class InternalCorporateDisqualificationMapperTest {
         assertThat(disqualificationDelta).isNotNull();
         assertThat(disqualificationTarget).isNotNull();
         assertEquals(externalDisqualificationTarget.getName(), "BOOMSHACK LTD.");
-        assertEquals(externalDisqualificationTarget.getOfficerDetailId(), null);
-        assertEquals(externalDisqualificationTarget.getOfficerDisqId(), null);
+        assertEquals(internalDisqualificationTarget.getOfficerDetailId(), null);
+        assertEquals(internalDisqualificationTarget.getOfficerDisqId(), null);
+        assertEquals(internalDisqualificationTarget.getOfficerId(), "D7WbjxLxswJPHWaLzilZ98PoaZU");
+        assertEquals(internalDisqualificationTarget.getOfficerIdRaw(), "1234554321");
         assertEquals(externalDisqualificationTarget.getPersonNumber(), null);
         assertEquals(externalDisqualificationTarget.getPermissionsToAct().get(0), permissionToAct);
+        assertEquals(externalDisqualificationTarget.getLinks(), 
+                "/disqualifiedofficer/corporate/D7WbjxLxswJPHWaLzilZ98PoaZU");
+        assertEquals(externalDisqualificationTarget.getCompanyNumber(), "0000000012");
+        assertEquals(externalDisqualificationTarget.getCountryOfRegistration(), "England");
 
         Disqualification disqualification = externalDisqualificationTarget.getDisqualifications().get(0);
         System.out.println(externalDisqualificationTarget);

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalNaturalDisqualificationMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalNaturalDisqualificationMapperTest.java
@@ -1,0 +1,110 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.mapper;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.util.FileCopyUtils;
+
+import uk.gov.companieshouse.api.delta.DisqualificationDelta;
+import uk.gov.companieshouse.api.delta.DisqualificationOfficer;
+import uk.gov.companieshouse.api.disqualification.Disqualification;
+import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.LastVariation;
+import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.PermissionToAct;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {
+        InternalNaturalDisqualificationMapperImpl.class,
+        DisqualificationMapperImpl.class,
+        PermissionToActMapperImpl.class})
+class InternalNaturalDisqualificationMapperTest {
+
+    private ObjectMapper mapper;
+    private DisqualificationDelta disqualificationDelta;
+    private DisqualificationOfficer disqualificationOfficer;
+
+    @Autowired
+    InternalNaturalDisqualificationMapper disqualificationMapper;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        mapper = new ObjectMapper();
+
+        String path = "disqualified-officers-natural-example.json";
+        String input =
+                FileCopyUtils.copyToString(new InputStreamReader(ClassLoader.getSystemClassLoader().getResourceAsStream(path)));
+
+        disqualificationDelta = mapper.readValue(input, DisqualificationDelta.class);
+        disqualificationOfficer = disqualificationDelta.getDisqualifiedOfficer().get(0);
+    }
+
+
+    @Test
+    void shouldMapDisqualificationOfficerToNaturalDisqualification() {
+        InternalNaturalDisqualificationApi disqualificationTarget =
+        disqualificationMapper.disqualificationDeltaToApi(disqualificationOfficer);
+        NaturalDisqualificationApi externalDisqualificationTarget = disqualificationTarget.getExternalData();
+
+        PermissionToAct permissionToAct = new PermissionToAct();
+        List<String> companyNames = new ArrayList<>();
+        companyNames.add("123 LTD");
+        companyNames.add("321 LTD");
+        permissionToAct.setCompanyNames(companyNames);
+        permissionToAct.setCourtName("rinder");
+        permissionToAct.setExpiresOn(LocalDate.of(2016, 04, 12));
+        permissionToAct.setGrantedOn(LocalDate.of(2014, 02, 03));
+
+        assertThat(disqualificationDelta).isNotNull();
+        assertThat(disqualificationTarget).isNotNull();
+        assertEquals(externalDisqualificationTarget.getForename(), "Dust");
+        assertEquals(externalDisqualificationTarget.getDateOfBirth(), LocalDate.of(1976, 02, 06));
+        assertEquals(externalDisqualificationTarget.getSurname(), "KINDNESSLIQUOR");
+        assertTrue(externalDisqualificationTarget.getHonours().isEmpty());
+        assertEquals(externalDisqualificationTarget.getNationality(), "British");
+        assertEquals(externalDisqualificationTarget.getOfficerDetailId(), "3002560732");
+        assertEquals(externalDisqualificationTarget.getOfficerDisqId(), "3000034602");
+        assertEquals(externalDisqualificationTarget.getTitle(), "Mr");
+        assertEquals(externalDisqualificationTarget.getPersonNumber(), "166284060001");
+        assertEquals(externalDisqualificationTarget.getOtherForenames(), "Condition Reserve");
+        assertEquals(externalDisqualificationTarget.getPermissionsToAct().get(0), permissionToAct);
+
+        Disqualification disqualification = externalDisqualificationTarget.getDisqualifications().get(0);
+        assertEquals(disqualification.getCaseIdentifier(), "INV3975227");
+        List<String> list = new ArrayList<>();
+        list.add("CONSORTIUM TECHNOLOGY LIMITED");
+        assertEquals(disqualification.getCompanyNames(), list);
+        assertNull(disqualification.getCourtName());
+        LastVariation var = new LastVariation();
+        var.setVariedOn(LocalDate.of(2021, 02, 17));
+        var.setCaseIdentifier("1");
+        var.setCourtName("Judys");
+        assertEquals(var, disqualification.getLastVariation().get(0));
+        assertEquals(disqualification.getDisqualificationType(), "undertaking");
+        HashMap<String, String> reason = new HashMap<>();
+        reason.put("act", "company-directors-disqualification-act-1986");
+        reason.put("section", "7");
+        reason.put("description_identifier", "order-or-undertaking-and-reporting-provisions");
+        assertEquals(disqualification.getReason(), reason);
+        assertEquals(disqualification.getUndertakenOn(), LocalDate.of(2015, 02, 14));
+        assertEquals(disqualification.getDisqualifiedFrom(), LocalDate.of(2015, 02, 18));
+        assertEquals(disqualification.getDisqualifiedUntil(), LocalDate.of(2025, 02, 17));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalNaturalDisqualificationMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalNaturalDisqualificationMapperTest.java
@@ -20,6 +20,7 @@ import org.springframework.util.FileCopyUtils;
 import uk.gov.companieshouse.api.delta.DisqualificationDelta;
 import uk.gov.companieshouse.api.delta.DisqualificationOfficer;
 import uk.gov.companieshouse.api.disqualification.Disqualification;
+import uk.gov.companieshouse.api.disqualification.InternalDisqualificationApiInternalData;
 import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.LastVariation;
 import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
@@ -62,6 +63,8 @@ class InternalNaturalDisqualificationMapperTest {
         InternalNaturalDisqualificationApi disqualificationTarget =
         disqualificationMapper.disqualificationDeltaToApi(disqualificationOfficer);
         NaturalDisqualificationApi externalDisqualificationTarget = disqualificationTarget.getExternalData();
+        InternalDisqualificationApiInternalData internalDisqualificationTarget = disqualificationTarget
+                .getInternalData();
 
         PermissionToAct permissionToAct = new PermissionToAct();
         List<String> companyNames = new ArrayList<>();
@@ -79,8 +82,10 @@ class InternalNaturalDisqualificationMapperTest {
         assertEquals(externalDisqualificationTarget.getSurname(), "KINDNESSLIQUOR");
         assertTrue(externalDisqualificationTarget.getHonours().isEmpty());
         assertEquals(externalDisqualificationTarget.getNationality(), "British");
-        assertEquals(externalDisqualificationTarget.getOfficerDetailId(), "3002560732");
-        assertEquals(externalDisqualificationTarget.getOfficerDisqId(), "3000034602");
+        assertEquals(internalDisqualificationTarget.getOfficerDetailId(), "3002560732");
+        assertEquals(internalDisqualificationTarget.getOfficerDisqId(), "3000034602");
+        assertEquals(internalDisqualificationTarget.getOfficerId(), "1kETe9SJWIp9OlvZgO1xmjyt5_s");
+        assertEquals(internalDisqualificationTarget.getOfficerIdRaw(), "1234567890");
         assertEquals(externalDisqualificationTarget.getTitle(), "Mr");
         assertEquals(externalDisqualificationTarget.getPersonNumber(), "166284060001");
         assertEquals(externalDisqualificationTarget.getOtherForenames(), "Condition Reserve");

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersProcessorTest.java
@@ -10,10 +10,14 @@ import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.FileCopyUtils;
-import uk.gov.companieshouse.api.delta.*;
+import uk.gov.companieshouse.api.delta.Disqualification;
+import uk.gov.companieshouse.api.delta.DisqualificationAddress;
+import uk.gov.companieshouse.api.delta.DisqualificationDelta;
+import uk.gov.companieshouse.api.delta.DisqualificationOfficer;
 import uk.gov.companieshouse.delta.ChsDelta;
 import uk.gov.companieshouse.disqualifiedofficers.delta.producer.DisqualifiedOfficersDeltaProducer;
 import uk.gov.companieshouse.disqualifiedofficers.delta.transformer.DisqualifiedOfficersApiTransformer;
+import uk.gov.companieshouse.logging.Logger;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -28,13 +32,18 @@ public class DisqualifiedOfficersProcessorTest {
 
     @Mock
     private DisqualifiedOfficersDeltaProducer disqualifiedOfficersDeltaProducer;
-
     @Mock
     private DisqualifiedOfficersApiTransformer transformer;
+    @Mock
+    private Logger logger;
 
     @BeforeEach
     void setUp() {
-        deltaProcessor = new DisqualifiedOfficersDeltaProcessor(disqualifiedOfficersDeltaProducer, transformer);
+        deltaProcessor = new DisqualifiedOfficersDeltaProcessor(
+                disqualifiedOfficersDeltaProducer,
+                transformer,
+                logger
+        );
     }
 
     @Test
@@ -42,11 +51,11 @@ public class DisqualifiedOfficersProcessorTest {
     void When_ValidChsDeltaMessage_Expect_ValidDisqualificationDeltaMapping() throws IOException {
         Message<ChsDelta> mockChsDeltaMessage = createChsDeltaMessage();
         DisqualificationDelta expectedDelta = createDisqualificationDelta();
-        when(transformer.transform(expectedDelta)).thenCallRealMethod();
+        when(transformer.transformNaturalDisqualification(expectedDelta)).thenCallRealMethod();
 
         deltaProcessor.processDelta(mockChsDeltaMessage);
 
-        verify(transformer).transform(expectedDelta);
+        verify(transformer).transformNaturalDisqualification(expectedDelta);
     }
 
     private Message<ChsDelta> createChsDeltaMessage() throws IOException {

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/transformer/DisqualifiedOfficersApiTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/transformer/DisqualifiedOfficersApiTransformerTest.java
@@ -1,17 +1,85 @@
 package uk.gov.companieshouse.disqualifiedofficers.delta.transformer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import uk.gov.companieshouse.api.delta.DisqualificationDelta;
-
+import uk.gov.companieshouse.api.delta.DisqualificationOfficer;
+import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
+import uk.gov.companieshouse.disqualifiedofficers.delta.mapper.InternalCorporateDisqualificationMapper;
+import uk.gov.companieshouse.disqualifiedofficers.delta.mapper.InternalNaturalDisqualificationMapper;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.util.ArrayList;
+import java.util.List;
 
+@ExtendWith(MockitoExtension.class)
 public class DisqualifiedOfficersApiTransformerTest {
-    private final DisqualifiedOfficersApiTransformer transformer = new DisqualifiedOfficersApiTransformer();
 
-    @Test
-    public void transformSuccessfully() {
-        final DisqualificationDelta input = new DisqualificationDelta();
-        assertThat(transformer.transform(input)).isEqualTo(input.toString());
+    @Mock
+    private InternalNaturalDisqualificationMapper naturalMapper;
+    @Mock
+    private InternalCorporateDisqualificationMapper corporateMapper;
+    private DisqualifiedOfficersApiTransformer transformer;
+
+    @BeforeEach
+    public void setup() {
+         transformer = new DisqualifiedOfficersApiTransformer(
+            corporateMapper, naturalMapper
+        );
     }
 
+    @Test
+    public void transformNaturalDeltaSuccessfully() {
+        DisqualificationDelta input = new DisqualificationDelta();
+        List<DisqualificationOfficer> disqualifiedOfficerList = new ArrayList<>();
+        disqualifiedOfficerList.add(new DisqualificationOfficer());
+        input.setDisqualifiedOfficer(disqualifiedOfficerList);
+        input.setDeltaAt("20211008152823383176");
+
+        DisqualificationOfficer disqualificationOfficer = input.getDisqualifiedOfficer().get(0);
+        InternalNaturalDisqualificationApi mock = mock(InternalNaturalDisqualificationApi.class);
+
+        when(naturalMapper.disqualificationDeltaToApi(disqualificationOfficer)).thenReturn(mock);
+
+        InternalNaturalDisqualificationApi actual = transformer.transformNaturalDisqualification(input);
+        assertThat(actual).isEqualTo(mock);
+    }
+
+    @Test
+    public void transformCorporateDeltaSuccessfully() {
+        DisqualificationDelta input = new DisqualificationDelta();
+        List<DisqualificationOfficer> disqualifiedOfficerList = new ArrayList<>();
+        disqualifiedOfficerList.add(new DisqualificationOfficer());
+        input.setDisqualifiedOfficer(disqualifiedOfficerList);
+        input.setDeltaAt("20211008152823383176");
+
+        DisqualificationOfficer disqualificationOfficer = input.getDisqualifiedOfficer().get(0);
+        InternalCorporateDisqualificationApi mock = mock(InternalCorporateDisqualificationApi.class);
+
+        when(corporateMapper.disqualificationDeltaToApi(disqualificationOfficer)).thenReturn(mock);
+
+        InternalCorporateDisqualificationApi actual = transformer.transformCorporateDisqualification(input);
+        assertThat(actual).isEqualTo(mock);
+    }
+
+    @Test
+    void errorDuringTransformationThrowsNullPointer() {
+        DisqualificationDelta input = new DisqualificationDelta();
+        List<DisqualificationOfficer> disqualifiedOfficerList = new ArrayList<>();
+        disqualifiedOfficerList.add(new DisqualificationOfficer());
+        input.setDisqualifiedOfficer(disqualifiedOfficerList);
+
+        DisqualificationOfficer disqualificationOfficer = input.getDisqualifiedOfficer().get(0);
+
+        when(naturalMapper.disqualificationDeltaToApi(disqualificationOfficer))
+                .thenThrow(NullPointerException.class);
+        assertThrows(NullPointerException.class, () -> transformer.transformNaturalDisqualification(input));
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/transformer/DisqualifiedOfficersApiTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/transformer/DisqualifiedOfficersApiTransformerTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.delta.DisqualificationDelta;
 import uk.gov.companieshouse.api.delta.DisqualificationOfficer;
 import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.InternalDisqualificationApiInternalData;
 import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
 import uk.gov.companieshouse.disqualifiedofficers.delta.mapper.InternalCorporateDisqualificationMapper;
 import uk.gov.companieshouse.disqualifiedofficers.delta.mapper.InternalNaturalDisqualificationMapper;
@@ -47,6 +48,7 @@ public class DisqualifiedOfficersApiTransformerTest {
         InternalNaturalDisqualificationApi mock = mock(InternalNaturalDisqualificationApi.class);
 
         when(naturalMapper.disqualificationDeltaToApi(disqualificationOfficer)).thenReturn(mock);
+        when(mock.getInternalData()).thenReturn(new InternalDisqualificationApiInternalData());
 
         InternalNaturalDisqualificationApi actual = transformer.transformNaturalDisqualification(input);
         assertThat(actual).isEqualTo(mock);
@@ -64,6 +66,7 @@ public class DisqualifiedOfficersApiTransformerTest {
         InternalCorporateDisqualificationApi mock = mock(InternalCorporateDisqualificationApi.class);
 
         when(corporateMapper.disqualificationDeltaToApi(disqualificationOfficer)).thenReturn(mock);
+        when(mock.getInternalData()).thenReturn(new InternalDisqualificationApiInternalData());
 
         InternalCorporateDisqualificationApi actual = transformer.transformCorporateDisqualification(input);
         assertThat(actual).isEqualTo(mock);

--- a/src/test/resources/disqualified-officers-corporate-example.json
+++ b/src/test/resources/disqualified-officers-corporate-example.json
@@ -1,0 +1,81 @@
+{
+  "delta_at": "20151118154448000000",
+  "disqualified_officer": [
+    {
+      "officer_id": "12345",
+      "corporate_ind": "1",
+      "registered_location": "England",
+      "registered_number": "0000000012",
+      "surname": "BOOMSHACK LTD.",
+      "disqualifications": [
+        {
+          "address": {
+            "address_line_1": "Crown Way",
+            "address_line_2": "Maindy",
+            "country": "Wales",
+            "locality": "Cardiff",
+            "postal_code": "CF14 3UZ",
+            "premise": "Companies House",
+            "region": "South Glamorgan"
+          },
+          "court_ref": "IME3707935",
+          "court_name": "UNDERTAKING",
+          "company_names": [
+            "TEEHEE LIMITED",
+            "HOOHAH LIMITED"
+          ],
+          "disq_eff_date": "20130624",
+          "disq_end_date": "20180623",
+          "disq_type": "ORDER",
+          "hearing_date": "20130101",
+          "section_of_the_act": "CDDO 1986 S4",
+          "variation_court": "CHDBALDWIN",
+          "variation_court_ref_no": "VARY DQ01 EFF DATE TO CURRENT",
+          "var_instrument_start_date": "20151117"
+        },
+        {
+          "address": {
+            "address_line_1": "34 Tudor Mews",
+            "address_line_2": "Miskin",
+            "country": "Wales",
+            "locality": "Cardiff",
+            "postal_code": "CF72 8SL",
+            "premise": "Companies House",
+            "region": "Rhonda Cynon Taff"
+          },
+          "court_ref": "ABC123",
+          "court_name": "Cardiff",
+          "company_names": [
+            "JAMIE LTD",
+            "CHELLO LTD"
+          ],
+          "disq_eff_date": "20110621",
+          "disq_end_date": "20160123",
+          "disq_type": "ORDER",
+          "hearing_date": "20110501",
+          "section_of_the_act": "CDDA 1986 S9"
+        }
+      ],
+      "exemptions": [
+        {
+          "court_name": "CARDIFF",
+          "expires_on": "20150223",
+          "granted_on": "20130515",
+          "company_names": [
+            "TEST1 LTD",
+            "TEST LTD"
+          ]
+        },
+        {
+          "court_name": "CHDB",
+          "expires_on": "20130101",
+          "granted_on": "20080819",
+          "company_names": [
+            "Test Company LTD",
+            "Another Test Company LTD"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/disqualified-officers-corporate-example.json
+++ b/src/test/resources/disqualified-officers-corporate-example.json
@@ -2,7 +2,7 @@
   "delta_at": "20151118154448000000",
   "disqualified_officer": [
     {
-      "officer_id": "12345",
+      "officer_id": "1234554321",
       "corporate_ind": "1",
       "registered_location": "England",
       "registered_number": "0000000012",

--- a/src/test/resources/disqualified-officers-natural-example.json
+++ b/src/test/resources/disqualified-officers-natural-example.json
@@ -1,0 +1,56 @@
+{
+    "disqualified_officer": [
+      {
+        "officer_disq_id": "3000034602",
+        "external_number": "166284060001",
+        "officer_id": "3002047713",
+        "officer_detail_id": "3002560732",
+        "date_of_birth": "19760206",
+        "title": "Mr",
+        "forename": "Dust",
+        "middle_name": "Condition Reserve",
+        "surname": "KINDNESSLIQUOR",
+        "honours": "",
+        "nationality": "British",
+        "registered_number": "",
+        "registered_location": "",
+        "disqualifications": [
+          {
+            "disq_eff_date": "20150218",
+            "disq_end_date": "20250217",
+            "disq_type": "UNDERTAKING",
+            "hearing_date": "20150214",
+            "section_of_the_act": "CDDA 1986 S7",
+            "court_ref": "INV3975227",
+            "court_name": "Insolvency Service",
+            "address": {
+              "premise": "30",
+              "address_line_1": "Lucy Road",
+              "address_line_2": "Skewen",
+              "locality": "Neath",
+              "region": "",
+              "country": "Wales",
+              "postal_code": "SA10 6RR"
+            },
+            "variation_court": "Judys",
+            "variation_court_ref_no": "1",
+            "var_instrument_start_date": "20210217",
+            "company_names": [
+              "CONSORTIUM TECHNOLOGY LIMITED"
+            ]
+          }
+        ],
+        "exemptions": [{
+          "court_name": "rinder",
+          "granted_on": "20140203",
+          "expires_on": "20160412",
+          "company_names": [
+              "123 LTD",
+              "321 LTD"
+          ]
+      }]
+      }
+    ],
+    "CreatedTime": "16-FEB-22 14.40.57.000000",
+    "delta_at": "20211008152823383176"
+  }

--- a/src/test/resources/disqualified-officers-natural-example.json
+++ b/src/test/resources/disqualified-officers-natural-example.json
@@ -3,7 +3,7 @@
       {
         "officer_disq_id": "3000034602",
         "external_number": "166284060001",
-        "officer_id": "3002047713",
+        "officer_id": "1234567890",
         "officer_detail_id": "3002560732",
         "date_of_birth": "19760206",
         "title": "Mr",


### PR DESCRIPTION
This PR adds a mapping for disqualified officers deltas (corporate and natural) to transform them into their respective internal api objects.

**Resolves**
DSND-578