### PR TITLE
Change last variation to be a single object

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <ch-kafka.version>1.4.2</ch-kafka.version>
         <structured-logging.version>1.9.12</structured-logging.version>
         <kafka-models.version>1.0.25</kafka-models.version>
-        <private-api-sdk-java.version>2.0.141</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.146</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
         <skip.integration.tests>false</skip.integration.tests>

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/DisqualificationMapper.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/DisqualificationMapper.java
@@ -52,9 +52,7 @@ public interface DisqualificationMapper {
         lastVariation.setCaseIdentifier(sourceDisq.getVariationCourtRefNo());
         lastVariation.setCourtName(sourceDisq.getVariationCourt());
         
-        List<LastVariation> lastVarList = new ArrayList<>();
-        lastVarList.add(lastVariation);
-        target.setLastVariation(lastVarList);
+        target.setLastVariation(lastVariation);
     }
 
     /**

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalCorporateDisqualificationMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalCorporateDisqualificationMapperTest.java
@@ -100,7 +100,7 @@ class InternalCorporateDisqualificationMapperTest {
         var.setVariedOn(LocalDate.of(2015, 11, 17));
         var.setCaseIdentifier("VARY DQ01 EFF DATE TO CURRENT");
         var.setCourtName("CHDBALDWIN");
-        assertEquals(var, disqualification.getLastVariation().get(0));
+        assertEquals(var, disqualification.getLastVariation());
         assertEquals(disqualification.getDisqualificationType(), "court-order");
         HashMap<String, String> reason = new HashMap<>();
         reason.put("act", "company-directors-disqualification-northern-ireland-order-2002");

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalNaturalDisqualificationMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalNaturalDisqualificationMapperTest.java
@@ -105,7 +105,7 @@ class InternalNaturalDisqualificationMapperTest {
         var.setVariedOn(LocalDate.of(2021, 02, 17));
         var.setCaseIdentifier("1");
         var.setCourtName("Judys");
-        assertEquals(var, disqualification.getLastVariation().get(0));
+        assertEquals(var, disqualification.getLastVariation());
         assertEquals(disqualification.getDisqualificationType(), "undertaking");
         HashMap<String, String> reason = new HashMap<>();
         reason.put("act", "company-directors-disqualification-act-1986");


### PR DESCRIPTION
This pr changes the last variation mapping to use a single object instead of an array