### PR TITLE
Send PUT request from disqualified officers delta consumer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <ch-kafka.version>1.4.2</ch-kafka.version>
         <structured-logging.version>1.9.12</structured-logging.version>
         <kafka-models.version>1.0.25</kafka-models.version>
-        <private-api-sdk-java.version>2.0.144</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.146</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
         <skip.integration.tests>false</skip.integration.tests>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <ch-kafka.version>1.4.2</ch-kafka.version>
         <structured-logging.version>1.9.12</structured-logging.version>
         <kafka-models.version>1.0.25</kafka-models.version>
-        <private-api-sdk-java.version>2.0.141</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.144</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
         <skip.integration.tests>false</skip.integration.tests>

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/handler/ApiResponseHandler.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/handler/ApiResponseHandler.java
@@ -1,0 +1,36 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.handler;
+
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.companieshouse.disqualifiedofficers.delta.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.disqualifiedofficers.delta.exception.RetryableErrorException;
+import uk.gov.companieshouse.logging.Logger;
+
+public class ApiResponseHandler {
+
+    /**
+     * Handle responses by logging result and throwing any exceptions.
+     */
+    public void handleResponse(
+            final ResponseStatusException ex,
+            final HttpStatus httpStatus,
+            final String logContext,
+            final String msg,
+            final Map<String, Object> logMap,
+            Logger logger)
+            throws NonRetryableErrorException, RetryableErrorException {
+        logMap.put("status", httpStatus.toString());
+        if (HttpStatus.BAD_REQUEST == httpStatus) {
+            // 400 BAD REQUEST status cannot be retried
+            logger.errorContext(logContext, msg, null, logMap);
+            throw new NonRetryableErrorException(msg);
+        } else if (httpStatus.is4xxClientError() || httpStatus.is5xxServerError()) {
+            // any other client or server status can be retried
+            logger.errorContext(logContext, msg + ", retry", null, logMap);
+            throw new RetryableErrorException(msg);
+        } else {
+            logger.debugContext(logContext, msg, logMap);
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
@@ -67,23 +67,23 @@ public class DisqualifiedOfficersDeltaProcessor {
             ObjectMapper mapper = new ObjectMapper();
             DisqualificationDelta disqualifiedOfficersDelta = mapper.readValue(payload.getData(),
                     DisqualificationDelta.class);
-
             DisqualificationOfficer disqualificationOfficer = disqualifiedOfficersDelta
                     .getDisqualifiedOfficer()
                     .get(0);
-
             if (Boolean.valueOf(disqualificationOfficer.getCorporateInd())) {
                 InternalCorporateDisqualificationApi apiObject = transformer
                         .transformCorporateDisqualification(disqualifiedOfficersDelta);
                 logger.info("InternalCorporateDisqualificationApi object" + apiObject);
                 //invoke disqualified officers API with Corporate method
-                invokeDisqualificationsDataApi(logContext, disqualificationOfficer, apiObject, logMap);
+                invokeDisqualificationsDataApi(logContext, disqualificationOfficer,
+                        apiObject, logMap);
             } else {
                 InternalNaturalDisqualificationApi apiObject = transformer
                         .transformNaturalDisqualification(disqualifiedOfficersDelta);
                 logger.info("InternalNaturalDisqualificationApi object" + apiObject);
                 //invoke disqualified officers API with Natural method
-                invokeDisqualificationsDataApi(logContext, disqualificationOfficer, apiObject, logMap);
+                invokeDisqualificationsDataApi(logContext, disqualificationOfficer, 
+                        apiObject, logMap);
             }
         } catch (RetryableErrorException ex) {
             retryDeltaMessage(chsDelta);
@@ -96,9 +96,10 @@ public class DisqualifiedOfficersDeltaProcessor {
     /**
      * Invoke Disqualifications Data API.
      */
-    private void invokeDisqualificationsDataApi(final String logContext, DisqualificationOfficer disqualification,
-                                      InternalNaturalDisqualificationApi internalDisqualificationApi,
-                                      final Map<String, Object> logMap) {
+    private void invokeDisqualificationsDataApi(final String logContext, 
+                        DisqualificationOfficer disqualification,
+                        InternalNaturalDisqualificationApi internalDisqualificationApi,
+                        final Map<String, Object> logMap) {
         logger.infoContext(
                 logContext,
                 String.format("Process disqualification for officer with id [%s]",
@@ -112,9 +113,10 @@ public class DisqualifiedOfficersDeltaProcessor {
                 "Response received from disqualified officers data api", logMap);
     }
 
-    private void invokeDisqualificationsDataApi(final String logContext, DisqualificationOfficer disqualification,
-                                        InternalCorporateDisqualificationApi internalDisqualificationApi,
-                                        final Map<String, Object> logMap) {
+    private void invokeDisqualificationsDataApi(final String logContext,
+                        DisqualificationOfficer disqualification,
+                        InternalCorporateDisqualificationApi internalDisqualificationApi,
+                        final Map<String, Object> logMap) {
         logger.infoContext(
                 logContext,
                 String.format("Process disqualification for officer with id [%s]",

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientService.java
@@ -1,0 +1,29 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.service.api;
+
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
+import uk.gov.companieshouse.api.model.ApiResponse;
+
+/**
+ * The {@code ApiClientService} interface provides an abstraction that can be
+ * used when testing {@code ApiClientManager} static methods, without imposing
+ * the use of a test framework that supports mocking of static methods.
+ */
+public interface ApiClientService {
+
+    InternalApiClient getApiClient(String contextId);
+
+    /**
+     * Submit disqualification.
+     */
+    ApiResponse<Void> putDisqualification(
+            final String log,
+            final String officerId,
+            final InternalNaturalDisqualificationApi internalDisqualificationApi);
+
+    ApiResponse<Void> putDisqualification(
+            final String log,
+            final String officerId,
+            final InternalCorporateDisqualificationApi internalDisqualificationApi);
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientServiceImpl.java
@@ -1,0 +1,90 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.service.api;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
+import uk.gov.companieshouse.api.http.ApiKeyHttpClient;
+import uk.gov.companieshouse.api.http.HttpClient;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.logging.Logger;
+
+
+/**
+ * Service that sends REST requests via private SDK.
+ */
+@Primary
+@Service
+public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements ApiClientService {
+
+    @Value("${api.disqualified-officers-data-api-key}")
+    private String chsApiKey;
+
+    @Value("${api.api-url}")
+    private String apiUrl;
+
+    /**
+     * Construct an {@link ApiClientServiceImpl}.
+     *
+     * @param logger the CH logger
+     */
+    @Autowired
+    public ApiClientServiceImpl(final Logger logger) {
+        super(logger);
+    }
+
+    @Override
+    public InternalApiClient getApiClient(String contextId) {
+        InternalApiClient internalApiClient = new InternalApiClient(getHttpClient(contextId));
+        internalApiClient.setBasePath(apiUrl);
+        return internalApiClient;
+    }
+
+    private HttpClient getHttpClient(String contextId) {
+        ApiKeyHttpClient httpClient = new ApiKeyHttpClient(chsApiKey);
+        httpClient.setRequestId(contextId);
+        return httpClient;
+    }
+
+    @Override
+    public ApiResponse<Void> putDisqualification(final String log, final String officerId,
+                                       InternalNaturalDisqualificationApi internalDisqualificationApi) {
+        final String uri = String.format("/disqualified-officers/natural/%s/internal",  officerId);
+
+        Map<String, Object> logMap = createLogMap(officerId, "PUT", uri);
+        logger.infoContext(log, String.format("PUT %s", uri), logMap);
+
+        return executeOp(log, "putDisqualification", uri,
+                getApiClient(log).privateDisqualificationResourceHandler()
+                        .putDisqualification()
+                        .upsert(uri, internalDisqualificationApi));
+    }
+
+    @Override
+    public ApiResponse<Void> putDisqualification(final String log, final String officerId,
+                                                 InternalCorporateDisqualificationApi internalDisqualificationApi) {
+        final String uri = String.format("/disqualified-officers/corporate/%s/internal",  officerId);
+
+        Map<String, Object> logMap = createLogMap(officerId, "PUT", uri);
+        logger.infoContext(log, String.format("PUT %s", uri), logMap);
+
+        return executeOp(log, "putDisqualification", uri,
+                getApiClient(log).privateDisqualificationResourceHandler()
+                        .putDisqualification()
+                        .upsert(uri, internalDisqualificationApi));
+    }
+
+    private Map<String, Object> createLogMap(String officerId, String method, String path) {
+        final Map<String, Object> logMap = new HashMap<>();
+        logMap.put("officer_id", officerId);
+        logMap.put("method", method);
+        logMap.put("path", path);
+        return logMap;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientServiceImpl.java
@@ -29,6 +29,9 @@ public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements Ap
     @Value("${api.api-url}")
     private String apiUrl;
 
+    @Value("${api.internal-api-url}")
+    private String internalApiUrl;
+
     /**
      * Construct an {@link ApiClientServiceImpl}.
      *
@@ -43,6 +46,7 @@ public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements Ap
     public InternalApiClient getApiClient(String contextId) {
         InternalApiClient internalApiClient = new InternalApiClient(getHttpClient(contextId));
         internalApiClient.setBasePath(apiUrl);
+        internalApiClient.setInternalBasePath(internalApiUrl);
         return internalApiClient;
     }
 
@@ -54,8 +58,8 @@ public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements Ap
 
     @Override
     public ApiResponse<Void> putDisqualification(final String log, final String officerId,
-                                       InternalNaturalDisqualificationApi internalDisqualificationApi) {
-        final String uri = String.format("/disqualified-officers/natural/%s/internal",  officerId);
+                            InternalNaturalDisqualificationApi internalDisqualificationApi) {
+        final String uri = String.format("/disqualified-officers/natural/%s/internal", officerId);
 
         Map<String, Object> logMap = createLogMap(officerId, "PUT", uri);
         logger.infoContext(log, String.format("PUT %s", uri), logMap);
@@ -68,8 +72,8 @@ public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements Ap
 
     @Override
     public ApiResponse<Void> putDisqualification(final String log, final String officerId,
-                                                 InternalCorporateDisqualificationApi internalDisqualificationApi) {
-        final String uri = String.format("/disqualified-officers/corporate/%s/internal",  officerId);
+                            InternalCorporateDisqualificationApi internalDisqualificationApi) {
+        final String uri = String.format("/disqualified-officers/corporate/%s/internal", officerId);
 
         Map<String, Object> logMap = createLogMap(officerId, "PUT", uri);
         logger.infoContext(log, String.format("PUT %s", uri), logMap);

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/BaseApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/BaseApiClientServiceImpl.java
@@ -1,0 +1,55 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.service.api;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.Executor;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.logging.Logger;
+
+public abstract class BaseApiClientServiceImpl {
+    protected Logger logger;
+
+    protected BaseApiClientServiceImpl(final Logger logger) {
+        this.logger = logger;
+    }
+
+    /**
+     * General execution of an SDK endpoint.
+     *
+     * @param <T>           type of api response
+     * @param logContext    context ID for logging
+     * @param operationName name of operation
+     * @param uri           uri of sdk being called
+     * @param executor      executor to use
+     * @return the response object
+     */
+    public <T> ApiResponse<T> executeOp(final String logContext,
+                                        final String operationName,
+                                        final String uri,
+                                        final Executor<ApiResponse<T>> executor) {
+
+        final Map<String, Object> logMap = new HashMap<>();
+        logMap.put("operation_name", operationName);
+        logMap.put("path", uri);
+
+        try {
+
+            return executor.execute();
+
+        } catch (URIValidationException ex) {
+            logger.errorContext(logContext, "SDK exception", ex, logMap);
+
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage(), ex);
+        } catch (ApiErrorResponseException ex) {
+            logMap.put("status", ex.getStatusCode());
+            logger.errorContext(logContext, "SDK exception", ex, logMap);
+
+            throw new ResponseStatusException(HttpStatus.valueOf(ex.getStatusCode()),
+                    ex.getStatusMessage(), ex);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,3 +25,4 @@ logger:
 api:
   disqualified-officers-data-api-key: ${DISQUALIFIED_OFFICERS_DATA_API_KEY:localhost}
   api-url: ${API_URL:localhost}
+  internal-api-url: ${INTERNAL_API_URL:localhost}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,3 +21,7 @@ disqualified-officers:
 
 logger:
   namespace: disqualified-officers-delta-consumer
+
+api:
+  disqualified-officers-data-api-key: ${DISQUALIFIED_OFFICERS_DATA_API_KEY:localhost}
+  api-url: ${API_URL:localhost}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/handler/ApiResponseHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/handler/ApiResponseHandlerTest.java
@@ -1,0 +1,55 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.handler;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.companieshouse.disqualifiedofficers.delta.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.disqualifiedofficers.delta.exception.RetryableErrorException;
+import uk.gov.companieshouse.logging.Logger;
+import java.util.HashMap;
+import java.util.Map;
+import static org.mockito.Mockito.verify;
+import static org.junit.Assert.assertThrows;
+
+
+@ExtendWith(MockitoExtension.class)
+class ApiResponseHandlerTest {
+
+    private ApiResponseHandler apiResponseHandler = new ApiResponseHandler();
+
+    @Mock
+    private Logger logger;
+    @Mock
+    ResponseStatusException ex;
+
+    @Test
+    void handle200Response() throws NonRetryableErrorException, RetryableErrorException {
+        HttpStatus httpStatus = HttpStatus.OK;
+        Map<String, Object> logMap = new HashMap<>();
+
+        apiResponseHandler.handleResponse(
+                ex, httpStatus,"status", "testy test test", logMap, logger );
+        verify(logger).debugContext("status", "testy test test", logMap);
+    }
+
+    @Test
+    void handleBadResponse() throws NonRetryableErrorException, RetryableErrorException {
+        HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+        Map<String, Object> logMap = new HashMap<>();
+        assertThrows(NonRetryableErrorException.class, () -> apiResponseHandler.handleResponse(
+                ex, httpStatus, "status", "testy test test", logMap, logger));
+        verify(logger).errorContext("status", "testy test test", null, logMap);
+    }
+
+    @Test
+    void handle500Response() throws NonRetryableErrorException, RetryableErrorException {
+        HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+        Map<String, Object> logMap = new HashMap<>();
+        assertThrows(RetryableErrorException.class, () -> apiResponseHandler.handleResponse(
+                ex, httpStatus, "status", "testy test test", logMap, logger));
+        verify(logger).errorContext("status", "testy test test, retry", null, logMap);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersProcessorTest.java
@@ -16,6 +16,7 @@ import uk.gov.companieshouse.api.delta.DisqualificationDelta;
 import uk.gov.companieshouse.api.delta.DisqualificationOfficer;
 import uk.gov.companieshouse.delta.ChsDelta;
 import uk.gov.companieshouse.disqualifiedofficers.delta.producer.DisqualifiedOfficersDeltaProducer;
+import uk.gov.companieshouse.disqualifiedofficers.delta.service.api.ApiClientService;
 import uk.gov.companieshouse.disqualifiedofficers.delta.transformer.DisqualifiedOfficersApiTransformer;
 import uk.gov.companieshouse.logging.Logger;
 
@@ -36,13 +37,17 @@ public class DisqualifiedOfficersProcessorTest {
     private DisqualifiedOfficersApiTransformer transformer;
     @Mock
     private Logger logger;
+    @Mock
+    private ApiClientService apiClientService;
+
 
     @BeforeEach
     void setUp() {
         deltaProcessor = new DisqualifiedOfficersDeltaProcessor(
                 disqualifiedOfficersDeltaProducer,
                 transformer,
-                logger
+                logger,
+                apiClientService
         );
     }
 

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientServiceImplTest.java
@@ -1,0 +1,83 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.service.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.delta.disqualification.request.PrivateNaturalDisqualificationUpsert;
+import uk.gov.companieshouse.api.handler.delta.disqualification.request.PrivateCorporateDisqualificationUpsert;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+
+@ExtendWith(MockitoExtension.class)
+class ApiClientServiceImplTest {
+
+    @Mock
+    Logger logger;
+
+    private ApiClientServiceImpl apiClientService;
+
+    @BeforeEach
+    void setup() {
+        apiClientService = new ApiClientServiceImpl(logger);
+        ReflectionTestUtils.setField(apiClientService, "chsApiKey", "apiKey");
+        ReflectionTestUtils.setField(apiClientService, "apiUrl", "https://api.companieshouse.gov.uk");
+    }
+
+    @Test
+    void putNaturalDisqualification() throws ApiErrorResponseException, URIValidationException {
+        final ApiResponse<Void> expectedResponse = new ApiResponse<>(HttpStatus.OK.value(), null, null);
+        ApiClientServiceImpl apiClientServiceSpy = Mockito.spy(apiClientService);
+        doReturn(expectedResponse).when(apiClientServiceSpy).executeOp(anyString(), anyString(),
+                anyString(),
+                any(PrivateNaturalDisqualificationUpsert.class));
+
+        ApiResponse<Void> response = apiClientServiceSpy.putDisqualification("context_id",
+                "ZTgzYWQwODAzMGY1ZDNkNGZiOTAxOWQ1YzJkYzc5MWViMTE3ZjQxZA==",
+                new InternalNaturalDisqualificationApi());
+        verify(apiClientServiceSpy).executeOp(anyString(), eq("putDisqualification"),
+                eq("/disqualified-officers/natural/" +
+                        "ZTgzYWQwODAzMGY1ZDNkNGZiOTAxOWQ1YzJkYzc5MWViMTE3ZjQxZA==/internal"),
+                any(PrivateNaturalDisqualificationUpsert.class));
+
+        assertThat(response).isEqualTo(expectedResponse);
+
+    }
+
+    @Test
+    void putCorporateDisqualification() throws ApiErrorResponseException, URIValidationException {
+        final ApiResponse<Void> expectedResponse = new ApiResponse<>(HttpStatus.OK.value(), null, null);
+        ApiClientServiceImpl apiClientServiceSpy = Mockito.spy(apiClientService);
+        doReturn(expectedResponse).when(apiClientServiceSpy).executeOp(anyString(), anyString(),
+                anyString(),
+                any(PrivateCorporateDisqualificationUpsert.class));
+
+        ApiResponse<Void> response = apiClientServiceSpy.putDisqualification("context_id",
+                "ZTgzYWQwODAzMGY1ZDNkNGZiOTAxOWQ1YzJkYzc5MWViMTE3ZjQxZA==",
+                new InternalCorporateDisqualificationApi());
+        verify(apiClientServiceSpy).executeOp(anyString(), eq("putDisqualification"),
+                eq("/disqualified-officers/corporate/" +
+                        "ZTgzYWQwODAzMGY1ZDNkNGZiOTAxOWQ1YzJkYzc5MWViMTE3ZjQxZA==/internal"),
+                any(PrivateCorporateDisqualificationUpsert.class));
+
+        assertThat(response).isEqualTo(expectedResponse);
+
+    }
+
+}


### PR DESCRIPTION
This PR adds an ApiClientService that creates a CH Internal API client and then uses it to execute a putDisqualification from the private-api-sdk, passing in the officerID and either a natural or corporate disqualified officer URI path.
This service is injected in the delta processor and then called in the invoke method which uses polymorphism to distinguish between natural and corporate.
A method was also added to handle the response and push to a logger map which was added.

**Resolves:**
- DSND-579