### PR TITLE
Feature/dsnd 749 corporate disq

### DIFF
--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
@@ -69,7 +69,8 @@ public class DisqualifiedOfficersDeltaProcessor {
             DisqualificationOfficer disqualificationOfficer = disqualifiedOfficersDelta
                     .getDisqualifiedOfficer()
                     .get(0);
-            if (Boolean.valueOf(disqualificationOfficer.getCorporateInd())) {
+            if (disqualificationOfficer.getCorporateInd() != null 
+                        && disqualificationOfficer.getCorporateInd().equals("1")) {
                 InternalCorporateDisqualificationApi apiObject = transformer
                         .transformCorporateDisqualification(disqualifiedOfficersDelta);
                 //invoke disqualified officers API with Corporate method
@@ -104,7 +105,7 @@ public class DisqualifiedOfficersDeltaProcessor {
                 null);
         final ApiResponse<Void> response =
                 apiClientService.putDisqualification(logContext,
-                        disqualification.getOfficerId(),
+                disqualification.getOfficerId(),
                         internalDisqualificationApi);
         ApiResponseHandler apiResponseHandler = new ApiResponseHandler();
         apiResponseHandler.handleResponse(null, HttpStatus.valueOf(response.getStatusCode()),
@@ -122,7 +123,7 @@ public class DisqualifiedOfficersDeltaProcessor {
                 null);
         final ApiResponse<Void> response =
                 apiClientService.putDisqualification(logContext,
-                        disqualification.getOfficerId(),
+                disqualification.getOfficerId(),
                         internalDisqualificationApi);
         ApiResponseHandler apiResponseHandler = new ApiResponseHandler();
         apiResponseHandler.handleResponse(null, HttpStatus.valueOf(response.getStatusCode()),

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
@@ -105,7 +105,7 @@ public class DisqualifiedOfficersDeltaProcessor {
                 null);
         final ApiResponse<Void> response =
                 apiClientService.putDisqualification(logContext,
-                disqualification.getOfficerId(),
+                        disqualification.getOfficerId(),
                         internalDisqualificationApi);
         ApiResponseHandler apiResponseHandler = new ApiResponseHandler();
         apiResponseHandler.handleResponse(null, HttpStatus.valueOf(response.getStatusCode()),
@@ -123,7 +123,7 @@ public class DisqualifiedOfficersDeltaProcessor {
                 null);
         final ApiResponse<Void> response =
                 apiClientService.putDisqualification(logContext,
-                disqualification.getOfficerId(),
+                        disqualification.getOfficerId(),
                         internalDisqualificationApi);
         ApiResponseHandler apiResponseHandler = new ApiResponseHandler();
         apiResponseHandler.handleResponse(null, HttpStatus.valueOf(response.getStatusCode()),


### PR DESCRIPTION
This PR corrects the corporate indicator check to work on a string of 1 to allow for the chips deltas being sent to be processed properly.

**Resolves**
DSND-749