### PR TITLE
Add integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 /target/
+
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,10 @@
                     <groupId>com.github.jknack</groupId>
                     <artifactId>handlebars-helpers</artifactId>
                 </exclusion>
+                <exclusion>
+					<groupId>net.javacrumbs.json-unit</groupId>
+					<artifactId>json-unit-core</artifactId>
+				</exclusion>
             </exclusions>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -170,9 +170,9 @@
                     <artifactId>handlebars-helpers</artifactId>
                 </exclusion>
                 <exclusion>
-					<groupId>net.javacrumbs.json-unit</groupId>
-					<artifactId>json-unit-core</artifactId>
-				</exclusion>
+                    <groupId>net.javacrumbs.json-unit</groupId>
+                    <artifactId>json-unit-core</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,14 @@
         <maven-build-helper-plugin.version>3.2.0</maven-build-helper-plugin.version>
         <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
         <docker-maven-plugin.version>1.0.0</docker-maven-plugin.version>
+        <io-cucumber.version>7.2.3</io-cucumber.version>
         <ch-kafka.version>1.4.2</ch-kafka.version>
         <structured-logging.version>1.9.12</structured-logging.version>
         <kafka-models.version>1.0.25</kafka-models.version>
         <private-api-sdk-java.version>2.0.146</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
+        <wiremock.standalone.version>2.32.0</wiremock.standalone.version>
         <skip.integration.tests>false</skip.integration.tests>
         <skip.unit.tests>false</skip.unit.tests>
 
@@ -123,6 +125,51 @@
             <artifactId>junit-jupiter</artifactId>
             <version>${test-containers.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-core</artifactId>
+            <version>${io-cucumber.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>${io-cucumber.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <version>${io-cucumber.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-spring</artifactId>
+            <version>${io-cucumber.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>${wiremock.standalone.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.conscrypt</groupId>
+                    <artifactId>conscrypt-openjdk-uber</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.jknack</groupId>
+                    <artifactId>handlebars</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.jknack</groupId>
+                    <artifactId>handlebars-helpers</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <map-struct.version>1.4.2.Final</map-struct.version>
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <maven-build-helper-plugin.version>3.2.0</maven-build-helper-plugin.version>
-        <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
+        <maven-failsafe-plugin.version>2.12.4</maven-failsafe-plugin.version>
         <docker-maven-plugin.version>1.0.0</docker-maven-plugin.version>
         <io-cucumber.version>7.2.3</io-cucumber.version>
         <ch-kafka.version>1.4.2</ch-kafka.version>

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/CucumberFeaturesRunnerITest.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/CucumberFeaturesRunnerITest.java
@@ -1,0 +1,14 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import io.cucumber.spring.CucumberContextConfiguration;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(features = "src/itest/resources/features",
+        plugin = {"pretty", "json:target/cucumber-report.json"})
+@CucumberContextConfiguration
+public class CucumberFeaturesRunnerITest extends AbstractIntegrationTest {
+
+}

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/config/KafkaTestContainerConfig.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/config/KafkaTestContainerConfig.java
@@ -60,7 +60,7 @@ public class KafkaTestContainerConfig {
         Map<String, Object> props = new HashMap<>();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        props.put(ConsumerConfig.GROUP_ID_CONFIG, "insolvency-delta-consumer");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "disqualified-officer-delta-consumer");
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ChsDeltaDeserializer.class);
         return props;

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/data/TestData.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/data/TestData.java
@@ -1,0 +1,33 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.data;
+
+import org.springframework.util.FileCopyUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class TestData {
+
+    public static String getInputData(String officerType, String disqType) {
+        disqType = disqType.replace(' ', '_');
+        String path = "src/itest/resources/data/" + officerType + '_' + disqType + "_in.json";
+        return readFile(path);
+    }
+
+    public static String getOutputData(String officerType, String disqType) {
+        disqType = disqType.replace(' ', '_');
+        String path = "src/itest/resources/data/" + officerType + '_' + disqType + "_out.json";
+        return readFile(path).replaceAll("\n", "");
+    }
+
+    private static String readFile(String path) {
+        String data;
+        try {
+            data = FileCopyUtils.copyToString(new InputStreamReader(new FileInputStream(new File(path))));
+        } catch (IOException e) {
+            data = null;
+        }
+        return data;
+    }
+}

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/matcher/DisqualificationRequestMatcher.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/matcher/DisqualificationRequestMatcher.java
@@ -1,0 +1,85 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.matcher;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.matching.MatchResult;
+import com.github.tomakehurst.wiremock.matching.ValueMatcher;
+import uk.gov.companieshouse.logging.Logger;
+
+public class DisqualificationRequestMatcher implements ValueMatcher<Request> {
+
+    private String expectedOutput;
+    private String type;
+    private Logger logger;
+
+    public DisqualificationRequestMatcher(Logger logger, String type, String output) {
+        this.type = type;
+        this.expectedOutput = output;
+        this.logger = logger;
+    }
+
+    @Override
+    public MatchResult match(Request value) {
+
+        return MatchResult.aggregate(matchUrl(value.getUrl()), matchMethod(value.getMethod()),
+                matchBody(value.getBodyAsString()));
+    }
+
+    private MatchResult matchUrl(String actualUrl) {
+        String expectedUrl = "/disqualified-officers/" + type + "/1234567890/internal";
+
+        MatchResult urlResult = MatchResult.of(expectedUrl.equals(actualUrl));
+
+        if (! urlResult.isExactMatch()) {
+            logger.error("url does not match expected: <" + expectedUrl + "> actual: <" + actualUrl + ">");
+        }
+
+        return urlResult;
+    }
+
+    private MatchResult matchMethod(RequestMethod actualMethod) {
+        RequestMethod expectedMethod = RequestMethod.PUT;
+
+        MatchResult typeResult = MatchResult.of(expectedMethod.equals(actualMethod));
+
+        if (! typeResult.isExactMatch()) {
+            logger.error("Method does not match expected: <" + expectedMethod + "> actual: <" + actualMethod + ">");
+        }
+
+        return typeResult;
+    }
+
+    private MatchResult matchBody(String actualBody) {
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        MatchResult bodyResult;
+        JsonNode expectedBody;
+        try {
+            expectedBody = mapper.readTree(expectedOutput);
+        } catch (JsonProcessingException e) {
+            logger.error("Could not process expectedBody JSON: " + e);
+            return MatchResult.of(false);
+        }
+
+        JsonNode actual;
+        try {
+            actual = mapper.readTree(actualBody);
+        } catch (JsonProcessingException e) {
+            logger.error("Could not process actualBody JSON: " + e);
+            return MatchResult.of(false);
+        }
+
+        bodyResult = MatchResult.of(expectedBody.equals(actual));
+
+        if (! bodyResult.isExactMatch()) {
+            logger.error("Body does not match expected: <" + expectedBody + "> actual: <" + actualBody + ">");
+        }
+
+        return bodyResult;
+    }
+}
+

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/matcher/DisqualificationRequestMatcher.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/matcher/DisqualificationRequestMatcher.java
@@ -9,6 +9,10 @@ import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.matching.ValueMatcher;
 import uk.gov.companieshouse.logging.Logger;
 
+/**
+ *  Custom matcher class used to match requests made by the consumer to the
+ *  data api. The url, request type and request body are compared.
+ */
 public class DisqualificationRequestMatcher implements ValueMatcher<Request> {
 
     private String expectedOutput;

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
@@ -1,0 +1,83 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.steps;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import uk.gov.companieshouse.delta.ChsDelta;
+import uk.gov.companieshouse.disqualifiedofficers.delta.data.TestData;
+import uk.gov.companieshouse.disqualifiedofficers.delta.matcher.DisqualificationRequestMatcher;
+import uk.gov.companieshouse.logging.Logger;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.requestMadeFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class CommonSteps {
+
+    private final static String ENCODED_OFFICER_ID = "1kETe9SJWIp9OlvZgO1xmjyt5_s";
+
+    @Value("${disqualified-officers.delta.topic.main}")
+    private String mainTopic;
+
+    @Value("${wiremock.server.port}")
+    private String port;
+
+    private static WireMockServer wireMockServer;
+
+    @Autowired
+    private KafkaTemplate<String, ChsDelta> kafkaTemplate;
+    @Autowired
+    private Logger logger;
+
+    private String type;
+    private String output;
+
+    @Given("the application is running")
+    public void theApplicationRunning() {
+        assertThat(kafkaTemplate).isNotNull();
+    }
+
+    @When("^the consumer receives a (natural|corporate) disqualification of (undertaking|court order)$")
+    public void theConsumerReceivesDisqualificationOfType(String officerType, String disqType) throws Exception {
+        configureWiremock();
+        stubPutDisqualification(officerType);
+        this.type = officerType;
+        this.output = TestData.getOutputData(officerType, disqType);
+
+        ChsDelta delta = new ChsDelta(TestData.getInputData(officerType, disqType), 1, "1");
+        kafkaTemplate.send(mainTopic, delta);
+
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        countDownLatch.await(5, TimeUnit.SECONDS);
+    }
+
+    @Then("a PUT request is sent to the disqualifications api with the transformed data")
+    public void putRequestIsSentToTheDisqualificationsApi() {
+        verify(1, requestMadeFor(new DisqualificationRequestMatcher(logger, type, output)));
+    }
+
+    private void configureWiremock() {
+        wireMockServer = new WireMockServer(Integer.parseInt(port));
+        wireMockServer.start();
+        configureFor("localhost", Integer.parseInt(port));
+    }
+
+    private void stubPutDisqualification(String type) {
+        stubFor(put(urlEqualTo("/disqualified-officers/" + type + "/1234567890/internal"))
+                .willReturn(aResponse().withStatus(200)));
+    }
+}
+

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
@@ -28,8 +28,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class CommonSteps {
 
-    private final static String ENCODED_OFFICER_ID = "1kETe9SJWIp9OlvZgO1xmjyt5_s";
-
     @Value("${disqualified-officers.delta.topic.main}")
     private String mainTopic;
 

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
@@ -66,6 +66,8 @@ public class CommonSteps {
 
     @Then("a PUT request is sent to the disqualifications api with the transformed data")
     public void putRequestIsSentToTheDisqualificationsApi() {
+        logger.info("I'm here" + output);
+        logger.info(type);
         verify(1, requestMadeFor(new DisqualificationRequestMatcher(logger, type, output)));
     }
 

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.disqualifiedofficers.delta.steps;
 
+import io.cucumber.java.After;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -66,9 +67,12 @@ public class CommonSteps {
 
     @Then("a PUT request is sent to the disqualifications api with the transformed data")
     public void putRequestIsSentToTheDisqualificationsApi() {
-        logger.info("I'm here" + output);
-        logger.info(type);
         verify(1, requestMadeFor(new DisqualificationRequestMatcher(logger, type, output)));
+    }
+
+    @After
+    public void shutdownWiremock(){
+        wireMockServer.stop();
     }
 
     private void configureWiremock() {

--- a/src/itest/resources/data/corporate_court_order_in.json
+++ b/src/itest/resources/data/corporate_court_order_in.json
@@ -1,0 +1,58 @@
+{
+    "disqualified_officer": [ 
+      {"corporate_ind":"true",
+        "officer_disq_id": "3000034602",
+        "external_number": "166284060001",
+        "officer_id": "rqaa9E",
+        "officer_detail_id": "3002560732",
+        "date_of_birth": "19760206",
+        "title": "",
+        "forename": "",
+        "middle_name": "",
+        "surname": "BABYLON INCORPORATION LIMITED",
+        "honours": "",
+        "nationality": "",
+        "registered_number": "00053723",
+        "registered_location": "SCOTLAND",
+        "disqualifications": [
+          {
+            "disq_eff_date": "20150218",
+            "disq_end_date": "20250217",
+            "disq_type": "ORDER",
+            "hearing_date": "20180214",
+            "section_of_the_act": "CDDO 1986 A11A",
+            "court_ref": "INV3975227",
+            "court_name": "Insolvency Service",
+            "address": {
+              "premise": "3000",
+              "address_line_1": "SYLVESTERucy AVENUE",
+              "address_line_2": "Skewen",
+              "locality": "Neath",
+              "region": "",
+              "country": "Wales",
+              "postal_code": "SA10 6RR"
+            },
+            "variation_court": "SWINDLERS",
+            "variation_court_ref_no": "1",
+            "var_instrument_start_date": "20210217",
+            "company_names": [
+              "CONSORTIUM TECHNOLOGY LIMITED"
+            ]
+          }
+        ],
+        "exemptions": [{
+          "court_name": "rinder",
+          "granted_on": "20140203",
+          "expires_on": "20160412",
+          "purpose": "ALPHABET",
+          "company_names": [
+              "123 LTD",
+              "321 LTD"
+
+          ]
+      }]
+      }
+    ],
+    "CreatedTime": "16-FEB-22 14.40.57.000000",
+    "delta_at": "20211008152823383176"
+  }

--- a/src/itest/resources/data/corporate_court_order_in.json
+++ b/src/itest/resources/data/corporate_court_order_in.json
@@ -1,58 +1,58 @@
 {
-    "disqualified_officer": [ 
-      {"corporate_ind":"true",
-        "officer_disq_id": "3000034602",
-        "external_number": "166284060001",
-        "officer_id": "rqaa9E",
-        "officer_detail_id": "3002560732",
-        "date_of_birth": "19760206",
-        "title": "",
-        "forename": "",
-        "middle_name": "",
-        "surname": "BABYLON INCORPORATION LIMITED",
-        "honours": "",
-        "nationality": "",
-        "registered_number": "00053723",
-        "registered_location": "SCOTLAND",
-        "disqualifications": [
-          {
-            "disq_eff_date": "20150218",
-            "disq_end_date": "20250217",
-            "disq_type": "ORDER",
-            "hearing_date": "20180214",
-            "section_of_the_act": "CDDO 1986 A11A",
-            "court_ref": "INV3975227",
-            "court_name": "Insolvency Service",
-            "address": {
-              "premise": "3000",
-              "address_line_1": "SYLVESTERucy AVENUE",
-              "address_line_2": "Skewen",
-              "locality": "Neath",
-              "region": "",
-              "country": "Wales",
-              "postal_code": "SA10 6RR"
-            },
-            "variation_court": "SWINDLERS",
-            "variation_court_ref_no": "1",
-            "var_instrument_start_date": "20210217",
-            "company_names": [
-              "CONSORTIUM TECHNOLOGY LIMITED"
-            ]
-          }
-        ],
-        "exemptions": [{
-          "court_name": "rinder",
-          "granted_on": "20140203",
-          "expires_on": "20160412",
-          "purpose": "ALPHABET",
+  "disqualified_officer": [ 
+    {"corporate_ind":"true",
+      "officer_disq_id": "3000034602",
+      "external_number": "166284060001",
+      "officer_id": "1234567890",
+      "officer_detail_id": "3002560732",
+      "date_of_birth": "19760206",
+      "title": "",
+      "forename": "",
+      "middle_name": "",
+      "surname": "BABYLON INCORPORATION LIMITED",
+      "honours": "",
+      "nationality": "",
+      "registered_number": "00053723",
+      "registered_location": "SCOTLAND",
+      "disqualifications": [
+        {
+          "disq_eff_date": "20150218",
+          "disq_end_date": "20250217",
+          "disq_type": "ORDER",
+          "hearing_date": "20180214",
+          "section_of_the_act": "CDDO 1986 A11A",
+          "court_ref": "INV3975227",
+          "court_name": "Insolvency Service",
+          "address": {
+            "premise": "3000",
+            "address_line_1": "SYLVESTERucy AVENUE",
+            "address_line_2": "Skewen",
+            "locality": "Neath",
+            "region": "",
+            "country": "Wales",
+            "postal_code": "SA10 6RR"
+          },
+          "variation_court": "SWINDLERS",
+          "variation_court_ref_no": "1",
+          "var_instrument_start_date": "20210217",
           "company_names": [
-              "123 LTD",
-              "321 LTD"
-
+            "CONSORTIUM TECHNOLOGY LIMITED"
           ]
-      }]
-      }
-    ],
-    "CreatedTime": "16-FEB-22 14.40.57.000000",
-    "delta_at": "20211008152823383176"
-  }
+        }
+      ],
+      "exemptions": [{
+        "court_name": "rinder",
+        "granted_on": "20140203",
+        "expires_on": "20160412",
+        "purpose": "ALPHABET",
+        "company_names": [
+            "123 LTD",
+            "321 LTD"
+
+        ]
+    }]
+    }
+  ],
+  "CreatedTime": "16-FEB-22 14.40.57.000000",
+  "delta_at": "20211008152823383176"
+}

--- a/src/itest/resources/data/corporate_court_order_in.json
+++ b/src/itest/resources/data/corporate_court_order_in.json
@@ -1,11 +1,10 @@
 {
   "disqualified_officer": [ 
-    {"corporate_ind":"true",
+    {"corporate_ind" : "1",
       "officer_disq_id": "3000034602",
       "external_number": "166284060001",
       "officer_id": "1234567890",
       "officer_detail_id": "3002560732",
-      "date_of_birth": "19760206",
       "title": "",
       "forename": "",
       "middle_name": "",

--- a/src/itest/resources/data/corporate_court_order_out.json
+++ b/src/itest/resources/data/corporate_court_order_out.json
@@ -1,0 +1,59 @@
+{
+    "external_data" : {
+        "person_number" : "person_number_123",
+        "date_of_birth" : "2022-03-05",
+        "etag" : "",
+        "title" : "string title",
+        "forename" : "string forename",
+        "other_forename" : "string other forename",
+        "surname" : "string surname",
+        "honours" : "string honours",
+        "nationality" : "string nationality",
+        "company_number" : "00000000",
+        "country_of_registration" : "string country",
+        "disqualifications" : [
+            {
+                "address" : {
+                    "address_line_1" : "123 String Road",
+                    "address_line_2" : "123 string line 2",
+                    "locality" : "123 string locality",
+                    "postal_code" : "123 string postcode",
+                    "premises" : "123 string premise",
+                    "region" : "123 string region",
+                    "country" : "string country"
+                },
+                "case_identifier" : "123 string caseid",
+                "company_names" : [
+                    "123 COMPANY NAME TEST"
+                ],
+                "court_name" : "123 string court name",
+                "disqualification_type" : "123 string disqualification type",
+                "disqualified_from" : "2022-03-03T12:51:00.767Z",
+                "disqualified_until" : "2022-03-04T12:51:00.767Z",
+                "heard_on" : "2022-03-01T12:51:00.767Z",
+                "undertaken_on" : null,
+                "reason" : {
+                    "description_identifier" : "123 string description identifier",
+                    "section" : "123 string section",
+                    "act" : "123 string act",
+                    "article" : "123 string article"
+                },
+                "last_variation" : {
+                    "court_name" : "string last variation court name",
+                    "case_identifier" : "string last variation caseid",
+                    "varied_on" : "2022-03-01"
+                }
+            }
+        ],
+        "links" : {
+            "self" : "123 link self"
+        }
+    },
+    "internal_data" : {
+        "delta_at" : "2022-04-11T11:18:00.768Z",
+        "officer_id" : "123 test officer id",
+        "officer_id_raw" : "123 test officer id raw",
+        "officer_disq_id" : "123 test officer disq id",
+        "officer_detail_id" : "123 test"
+    }
+}

--- a/src/itest/resources/data/corporate_court_order_out.json
+++ b/src/itest/resources/data/corporate_court_order_out.json
@@ -1,59 +1,62 @@
 {
     "external_data" : {
-        "person_number" : "person_number_123",
-        "date_of_birth" : "2022-03-05",
-        "etag" : "",
-        "title" : "string title",
-        "forename" : "string forename",
-        "other_forename" : "string other forename",
-        "surname" : "string surname",
-        "honours" : "string honours",
-        "nationality" : "string nationality",
-        "company_number" : "00000000",
-        "country_of_registration" : "string country",
+        "company_number" : "00053723",
+        "person_number" : "166284060001",
+        "country_of_registration" : "SCOTLAND",
+        "etag" : null,
+        "kind" : null,
+        "name" : "BABYLON INCORPORATION LIMITED",
+        "links" : {
+            "self" : "/disqualified-officers/corporate/1kETe9SJWIp9OlvZgO1xmjyt5_s"
+        },
         "disqualifications" : [
             {
-                "address" : {
-                    "address_line_1" : "123 String Road",
-                    "address_line_2" : "123 string line 2",
-                    "locality" : "123 string locality",
-                    "postal_code" : "123 string postcode",
-                    "premises" : "123 string premise",
-                    "region" : "123 string region",
-                    "country" : "string country"
+                "case_identifier" : "INV3975227",
+                "address": {
+                    "premise": "3000",
+                    "address_line_1": "SYLVESTERucy AVENUE",
+                    "address_line_2": "Skewen",
+                    "locality": "Neath",
+                    "region": "",
+                    "country": "Wales",
+                    "postal_code": "SA10 6RR"
                 },
-                "case_identifier" : "123 string caseid",
                 "company_names" : [
-                    "123 COMPANY NAME TEST"
+                    "CONSORTIUM TECHNOLOGY LIMITED"
                 ],
-                "court_name" : "123 string court name",
-                "disqualification_type" : "123 string disqualification type",
-                "disqualified_from" : "2022-03-03T12:51:00.767Z",
-                "disqualified_until" : "2022-03-04T12:51:00.767Z",
-                "heard_on" : "2022-03-01T12:51:00.767Z",
+                "court_name" : "Insolvency Service",
+                "disqualification_type" : "court-order",
+                "disqualified_from" : [2015,2,18],
+                "disqualified_until" : [2025,2,17],
+                "heard_on" : [2018,2,14],
                 "undertaken_on" : null,
-                "reason" : {
-                    "description_identifier" : "123 string description identifier",
-                    "section" : "123 string section",
-                    "act" : "123 string act",
-                    "article" : "123 string article"
+                "last_variation":{
+                    "varied_on" : [2021,2,17],
+                    "case_identifier" : "1",
+                    "court_name" : "SWINDLERS"
                 },
-                "last_variation" : {
-                    "court_name" : "string last variation court name",
-                    "case_identifier" : "string last variation caseid",
-                    "varied_on" : "2022-03-01"
+                "reason" : {
+                    "act" : "company-directors-disqualification-northern-ireland-order-2002",
+                    "description_identifier":"order-disqualifying-a-person-instructing-an-unfit-director-of-an-insolvent-company",
+                    "article":"11A"
                 }
             }
         ],
-        "links" : {
-            "self" : "123 link self"
-        }
+        "permissions_to_act": [
+            {
+                "company_names" : ["123 LTD","321 LTD"],
+                "court_name" : "rinder",
+                "expires_on":[2016,4,12],
+                "granted_on":[2014,2,3],
+                "purpose":"ALPHABET"
+            }
+        ]
     },
     "internal_data" : {
-        "delta_at" : "2022-04-11T11:18:00.768Z",
-        "officer_id" : "123 test officer id",
-        "officer_id_raw" : "123 test officer id raw",
-        "officer_disq_id" : "123 test officer disq id",
-        "officer_detail_id" : "123 test"
+        "delta_at" : 1.633706903383176E9,
+        "officer_id" : "1kETe9SJWIp9OlvZgO1xmjyt5_s",
+        "officer_id_raw" : "1234567890",
+        "officer_disq_id" : "3000034602",
+        "officer_detail_id" : "3002560732"
     }
 }

--- a/src/itest/resources/data/corporate_undertaking_in.json
+++ b/src/itest/resources/data/corporate_undertaking_in.json
@@ -1,0 +1,58 @@
+{
+    "disqualified_officer": [ 
+      {"corporate_ind":"true",
+        "officer_disq_id": "3000034602",
+        "external_number": "166284060001",
+        "officer_id": "rqaa9E",
+        "officer_detail_id": "3002560732",
+        "date_of_birth": "19760206",
+        "title": "",
+        "forename": "",
+        "middle_name": "",
+        "surname": "BABYLON INCORPORATION LIMITED",
+        "honours": "",
+        "nationality": "",
+        "registered_number": "00053723",
+        "registered_location": "SCOTLAND",
+        "disqualifications": [
+          {
+            "disq_eff_date": "20150218",
+            "disq_end_date": "20250217",
+            "disq_type": "ORDER",
+            "hearing_date": "20180214",
+            "section_of_the_act": "CDDO 1986 A11A",
+            "court_ref": "INV3975227",
+            "court_name": "Insolvency Service",
+            "address": {
+              "premise": "3000",
+              "address_line_1": "SYLVESTERucy AVENUE",
+              "address_line_2": "Skewen",
+              "locality": "Neath",
+              "region": "",
+              "country": "Wales",
+              "postal_code": "SA10 6RR"
+            },
+            "variation_court": "SWINDLERS",
+            "variation_court_ref_no": "1",
+            "var_instrument_start_date": "20210217",
+            "company_names": [
+              "CONSORTIUM TECHNOLOGY LIMITED"
+            ]
+          }
+        ],
+        "exemptions": [{
+          "court_name": "rinder",
+          "granted_on": "20140203",
+          "expires_on": "20160412",
+          "purpose": "ALPHABET",
+          "company_names": [
+              "123 LTD",
+              "321 LTD"
+
+          ]
+      }]
+      }
+    ],
+    "CreatedTime": "16-FEB-22 14.40.57.000000",
+    "delta_at": "20211008152823383176"
+  }

--- a/src/itest/resources/data/corporate_undertaking_in.json
+++ b/src/itest/resources/data/corporate_undertaking_in.json
@@ -1,11 +1,10 @@
 {
     "disqualified_officer": [ 
-      {"corporate_ind":"true",
+      {"corporate_ind":"1",
         "officer_disq_id": "3000034602",
         "external_number": "166284060001",
         "officer_id": "1234567890",
         "officer_detail_id": "3002560732",
-        "date_of_birth": "19760206",
         "title": "",
         "forename": "",
         "middle_name": "",

--- a/src/itest/resources/data/corporate_undertaking_in.json
+++ b/src/itest/resources/data/corporate_undertaking_in.json
@@ -3,7 +3,7 @@
       {"corporate_ind":"true",
         "officer_disq_id": "3000034602",
         "external_number": "166284060001",
-        "officer_id": "rqaa9E",
+        "officer_id": "1234567890",
         "officer_detail_id": "3002560732",
         "date_of_birth": "19760206",
         "title": "",
@@ -18,7 +18,7 @@
           {
             "disq_eff_date": "20150218",
             "disq_end_date": "20250217",
-            "disq_type": "ORDER",
+            "disq_type": "UNDERTAKING",
             "hearing_date": "20180214",
             "section_of_the_act": "CDDO 1986 A11A",
             "court_ref": "INV3975227",

--- a/src/itest/resources/data/corporate_undertaking_out.json
+++ b/src/itest/resources/data/corporate_undertaking_out.json
@@ -1,0 +1,59 @@
+{
+    "external_data" : {
+        "person_number" : "person_number_123",
+        "date_of_birth" : "2022-03-05",
+        "etag" : "",
+        "title" : "string title",
+        "forename" : "string forename",
+        "other_forename" : "string other forename",
+        "surname" : "string surname",
+        "honours" : "string honours",
+        "nationality" : "string nationality",
+        "company_number" : "00000000",
+        "country_of_registration" : "string country",
+        "disqualifications" : [
+            {
+                "address" : {
+                    "address_line_1" : "123 String Road",
+                    "address_line_2" : "123 string line 2",
+                    "locality" : "123 string locality",
+                    "postal_code" : "123 string postcode",
+                    "premises" : "123 string premise",
+                    "region" : "123 string region",
+                    "country" : "string country"
+                },
+                "case_identifier" : "123 string caseid",
+                "company_names" : [
+                    "123 COMPANY NAME TEST"
+                ],
+                "court_name" : "123 string court name",
+                "disqualification_type" : "123 string disqualification type",
+                "disqualified_from" : "2022-03-03T12:51:00.767Z",
+                "disqualified_until" : "2022-03-04T12:51:00.767Z",
+                "heard_on" : null,
+                "undertaken_on" : "2022-03-02T12:51:00.767Z",
+                "reason" : {
+                    "description_identifier" : "123 string description identifier",
+                    "section" : "123 string section",
+                    "act" : "123 string act",
+                    "article" : "123 string article"
+                },
+                "last_variation" : {
+                    "court_name" : "string last variation court name",
+                    "case_identifier" : "string last variation caseid",
+                    "varied_on" : "2022-03-01"
+                }
+            }
+        ],
+        "links" : {
+            "self" : "123 link self"
+        }
+    },
+    "internal_data" : {
+        "delta_at" : "2022-04-11T11:18:00.768Z",
+        "officer_id" : "123 test officer id",
+        "officer_id_raw" : "123 test officer id raw",
+        "officer_disq_id" : "123 test officer disq id",
+        "officer_detail_id" : "123 test"
+    }
+}

--- a/src/itest/resources/data/corporate_undertaking_out.json
+++ b/src/itest/resources/data/corporate_undertaking_out.json
@@ -1,59 +1,62 @@
 {
     "external_data" : {
-        "person_number" : "person_number_123",
-        "date_of_birth" : "2022-03-05",
-        "etag" : "",
-        "title" : "string title",
-        "forename" : "string forename",
-        "other_forename" : "string other forename",
-        "surname" : "string surname",
-        "honours" : "string honours",
-        "nationality" : "string nationality",
-        "company_number" : "00000000",
-        "country_of_registration" : "string country",
+        "company_number" : "00053723",
+        "person_number" : "166284060001",
+        "country_of_registration" : "SCOTLAND",
+        "etag" : null,
+        "kind" : null,
+        "name" : "BABYLON INCORPORATION LIMITED",
+        "links" : {
+            "self" : "/disqualified-officers/corporate/1kETe9SJWIp9OlvZgO1xmjyt5_s"
+        },
         "disqualifications" : [
             {
-                "address" : {
-                    "address_line_1" : "123 String Road",
-                    "address_line_2" : "123 string line 2",
-                    "locality" : "123 string locality",
-                    "postal_code" : "123 string postcode",
-                    "premises" : "123 string premise",
-                    "region" : "123 string region",
-                    "country" : "string country"
+                "case_identifier" : "INV3975227",
+                "address": {
+                    "premise": "3000",
+                    "address_line_1": "SYLVESTERucy AVENUE",
+                    "address_line_2": "Skewen",
+                    "locality": "Neath",
+                    "region": "",
+                    "country": "Wales",
+                    "postal_code": "SA10 6RR"
                 },
-                "case_identifier" : "123 string caseid",
                 "company_names" : [
-                    "123 COMPANY NAME TEST"
+                    "CONSORTIUM TECHNOLOGY LIMITED"
                 ],
-                "court_name" : "123 string court name",
-                "disqualification_type" : "123 string disqualification type",
-                "disqualified_from" : "2022-03-03T12:51:00.767Z",
-                "disqualified_until" : "2022-03-04T12:51:00.767Z",
+                "court_name" : null,
+                "disqualification_type" : "undertaking",
+                "disqualified_from" : [2015,2,18],
+                "disqualified_until" : [2025,2,17],
                 "heard_on" : null,
-                "undertaken_on" : "2022-03-02T12:51:00.767Z",
-                "reason" : {
-                    "description_identifier" : "123 string description identifier",
-                    "section" : "123 string section",
-                    "act" : "123 string act",
-                    "article" : "123 string article"
+                "undertaken_on" : [2018,2,14],
+                "last_variation":{
+                    "varied_on" : [2021,2,17],
+                    "case_identifier" : "1",
+                    "court_name" : "SWINDLERS"
                 },
-                "last_variation" : {
-                    "court_name" : "string last variation court name",
-                    "case_identifier" : "string last variation caseid",
-                    "varied_on" : "2022-03-01"
+                "reason" : {
+                    "act" : "company-directors-disqualification-northern-ireland-order-2002",
+                    "description_identifier":"order-disqualifying-a-person-instructing-an-unfit-director-of-an-insolvent-company",
+                    "article":"11A"
                 }
             }
         ],
-        "links" : {
-            "self" : "123 link self"
-        }
+        "permissions_to_act": [
+            {
+                "company_names" : ["123 LTD","321 LTD"],
+                "court_name" : "rinder",
+                "expires_on":[2016,4,12],
+                "granted_on":[2014,2,3],
+                "purpose":"ALPHABET"
+            }
+        ]
     },
     "internal_data" : {
-        "delta_at" : "2022-04-11T11:18:00.768Z",
-        "officer_id" : "123 test officer id",
-        "officer_id_raw" : "123 test officer id raw",
-        "officer_disq_id" : "123 test officer disq id",
-        "officer_detail_id" : "123 test"
+        "delta_at" : 1.633706903383176E9,
+        "officer_id" : "1kETe9SJWIp9OlvZgO1xmjyt5_s",
+        "officer_id_raw" : "1234567890",
+        "officer_disq_id" : "3000034602",
+        "officer_detail_id" : "3002560732"
     }
 }

--- a/src/itest/resources/data/natural_court_order_in.json
+++ b/src/itest/resources/data/natural_court_order_in.json
@@ -1,0 +1,56 @@
+{
+  "disqualified_officer": [
+    {
+      "officer_disq_id": "3000034602",
+      "external_number": "166284060001",
+      "officer_id": "1234567890",
+      "officer_detail_id": "3002560732",
+      "date_of_birth": "19760206",
+      "title": "Mr",
+      "forename": "Dust",
+      "middle_name": "Condition Reserve",
+      "surname": "KINDNESSLIQUOR",
+      "honours": "",
+      "nationality": "British",
+      "registered_number": "",
+      "registered_location": "",
+      "disqualifications": [
+        {
+          "disq_eff_date": "20150218",
+          "disq_end_date": "20250217",
+          "disq_type": "ORDER",
+          "hearing_date": "20150214",
+          "section_of_the_act": "CDDA 1986 S7",
+          "court_ref": "INV3975227",
+          "court_name": "Insolvency Service",
+          "address": {
+            "premise": "30",
+            "address_line_1": "Lucy Road",
+            "address_line_2": "Skewen",
+            "locality": "Neath",
+            "region": "",
+            "country": "Wales",
+            "postal_code": "SA10 6RR"
+          },
+          "variation_court": "Judys",
+          "variation_court_ref_no": "1",
+          "var_instrument_start_date": "20210217",
+          "company_names": [
+            "CONSORTIUM TECHNOLOGY LIMITED"
+          ]
+        }
+      ],
+      "exemptions": [{
+        "court_name": "rinder",
+        "granted_on": "20140203",
+        "expires_on": "20160412",
+        "company_names": [
+          "123 LTD",
+          "321 LTD"
+        ]
+      }]
+    }
+  ],
+  "CreatedTime": "16-FEB-22 14.40.57.000000",
+  "delta_at": "20211008152823383176"
+}

--- a/src/itest/resources/data/natural_court_order_out.json
+++ b/src/itest/resources/data/natural_court_order_out.json
@@ -1,0 +1,68 @@
+{
+  "external_data" : {
+    "date_of_birth": [1976,2,6],
+    "person_number" : "166284060001",
+    "etag" : null,
+    "forename" : "Dust",
+    "honours" : "",
+    "nationality" : "British",
+    "other_forenames" : "Condition Reserve",
+    "surname" : "KINDNESSLIQUOR",
+    "title" : "Mr",
+    "links" : {
+      "self" : "/disqualified-officers/natural/1kETe9SJWIp9OlvZgO1xmjyt5_s"
+    },
+    "disqualifications" : [
+      {
+        "case_identifier" : "INV3975227",
+        "address" : {
+          "premise" : "30",
+          "address_line_1" : "Lucy Road",
+          "address_line_2" : "Skewen",
+          "locality" : "Neath",
+          "region" : "",
+          "country" : "Wales",
+          "postal_code" : "SA10 6RR"
+        },
+        "company_names" : [
+          "CONSORTIUM TECHNOLOGY LIMITED"
+        ],
+        "court_name" : null,
+        "disqualification_type": "undertaking",
+        "disqualified_from" : [2015,2,18],
+        "disqualified_until" : [2025,2,17],
+        "heard_on" : [2015,2,14],
+        "undertaken_on" : null,
+        "last_variation" : {
+          "varied_on" : [2021,2,17],
+          "case_identifier" : "1",
+          "court_name" : "Judys"
+        },
+        "reason" : {
+          "act" : "company-directors-disqualification-act-1986",
+          "section" : "7",
+          "description_identifier" : "order-or-undertaking-and-reporting-provisions"
+        }
+      }
+    ],
+    "permissions_to_act": [
+      {
+        "company_names" : [
+          "123 LTD",
+          "321 LTD"
+        ],
+        "court_name" : "rinder",
+        "expires_on" : [2016,4,12],
+        "granted_on" : [2014,2,3],
+        "purpose" : null
+      }
+    ]
+  },
+  "internal_data" : {
+    "delta_at" : 1.633706903383176E9,
+    "officer_id" : "1kETe9SJWIp9OlvZgO1xmjyt5_s",
+    "officer_id_raw" : "1234567890",
+    "officer_disq_id" : "3000034602",
+    "officer_detail_id" : "3002560732"
+  }
+}

--- a/src/itest/resources/data/natural_court_order_out.json
+++ b/src/itest/resources/data/natural_court_order_out.json
@@ -27,8 +27,8 @@
         "company_names" : [
           "CONSORTIUM TECHNOLOGY LIMITED"
         ],
-        "court_name" : null,
-        "disqualification_type": "undertaking",
+        "court_name" : "Insolvency Service",
+        "disqualification_type": "court-order",
         "disqualified_from" : [2015,2,18],
         "disqualified_until" : [2025,2,17],
         "heard_on" : [2015,2,14],

--- a/src/itest/resources/data/natural_undertaking_in.json
+++ b/src/itest/resources/data/natural_undertaking_in.json
@@ -1,0 +1,56 @@
+{
+  "disqualified_officer": [
+    {
+      "officer_disq_id": "3000034602",
+      "external_number": "166284060001",
+      "officer_id": "1234567890",
+      "officer_detail_id": "3002560732",
+      "date_of_birth": "19760206",
+      "title": "Mr",
+      "forename": "Dust",
+      "middle_name": "Condition Reserve",
+      "surname": "KINDNESSLIQUOR",
+      "honours": "",
+      "nationality": "British",
+      "registered_number": "",
+      "registered_location": "",
+      "disqualifications": [
+        {
+          "disq_eff_date": "20150218",
+          "disq_end_date": "20250217",
+          "disq_type": "UNDERTAKING",
+          "hearing_date": "20150214",
+          "section_of_the_act": "CDDA 1986 S7",
+          "court_ref": "INV3975227",
+          "court_name": "Insolvency Service",
+          "address": {
+            "premise": "30",
+            "address_line_1": "Lucy Road",
+            "address_line_2": "Skewen",
+            "locality": "Neath",
+            "region": "",
+            "country": "Wales",
+            "postal_code": "SA10 6RR"
+          },
+          "variation_court": "Judys",
+          "variation_court_ref_no": "1",
+          "var_instrument_start_date": "20210217",
+          "company_names": [
+            "CONSORTIUM TECHNOLOGY LIMITED"
+          ]
+        }
+      ],
+      "exemptions": [{
+        "court_name": "rinder",
+        "granted_on": "20140203",
+        "expires_on": "20160412",
+        "company_names": [
+          "123 LTD",
+          "321 LTD"
+        ]
+      }]
+    }
+  ],
+  "CreatedTime": "16-FEB-22 14.40.57.000000",
+  "delta_at": "20211008152823383176"
+}

--- a/src/itest/resources/data/natural_undertaking_out.json
+++ b/src/itest/resources/data/natural_undertaking_out.json
@@ -1,0 +1,68 @@
+{
+  "external_data" : {
+    "date_of_birth": [1976,2,6],
+    "person_number" : "166284060001",
+    "etag" : null,
+    "forename" : "Dust",
+    "honours" : "",
+    "nationality" : "British",
+    "other_forenames" : "Condition Reserve",
+    "surname" : "KINDNESSLIQUOR",
+    "title" : "Mr",
+    "links" : {
+      "self" : "/disqualified-officers/natural/1kETe9SJWIp9OlvZgO1xmjyt5_s"
+    },
+    "disqualifications" : [
+      {
+        "case_identifier" : "INV3975227",
+        "address" : {
+          "premise" : "30",
+          "address_line_1" : "Lucy Road",
+          "address_line_2" : "Skewen",
+          "locality" : "Neath",
+          "region" : "",
+          "country" : "Wales",
+          "postal_code" : "SA10 6RR"
+        },
+        "company_names" : [
+          "CONSORTIUM TECHNOLOGY LIMITED"
+        ],
+        "court_name" : null,
+        "disqualification_type": "undertaking",
+        "disqualified_from" : [2015,2,18],
+        "disqualified_until" : [2025,2,17],
+        "heard_on" : null,
+        "undertaken_on" : [2015,2,14],
+        "last_variation" : {
+          "varied_on" : [2021,2,17],
+          "case_identifier" : "1",
+          "court_name" : "Judys"
+        },
+        "reason" : {
+          "act" : "company-directors-disqualification-act-1986",
+          "section" : "7",
+          "description_identifier" : "order-or-undertaking-and-reporting-provisions"
+        }
+      }
+    ],
+    "permissions_to_act": [
+      {
+        "company_names" : [
+          "123 LTD",
+          "321 LTD"
+        ],
+        "court_name" : "rinder",
+        "expires_on" : [2016,4,12],
+        "granted_on" : [2014,2,3],
+        "purpose" : null
+      }
+    ]
+  },
+  "internal_data" : {
+    "delta_at" : 1.633706903383176E9,
+    "officer_id" : "1kETe9SJWIp9OlvZgO1xmjyt5_s",
+    "officer_id_raw" : "1234567890",
+    "officer_disq_id" : "3000034602",
+    "officer_detail_id" : "3002560732"
+  }
+}

--- a/src/itest/resources/features/CorporateOfficer.feature
+++ b/src/itest/resources/features/CorporateOfficer.feature
@@ -1,8 +1,8 @@
-Feature: Natural Officer
+Feature: Corporate Officer
 
-Scenario Outline: Can transform and send a natural officer of <type>
+Scenario Outline: Can transform and send a corporate officer of <type>
   Given the application is running
-  When the consumer receives a natural disqualification of <type>
+  When the consumer receives a corporate disqualification of <type>
   Then a PUT request is sent to the disqualifications api with the transformed data
   Examples:
   | type        |

--- a/src/itest/resources/features/NaturalOfficer.feature
+++ b/src/itest/resources/features/NaturalOfficer.feature
@@ -1,0 +1,9 @@
+Feature: Natural Officer
+
+Scenario Outline: Can transform and send a natural officer
+  Given the application is running
+  When the consumer receives a natural disqualification of <type>
+  Then a PUT request is sent to the disqualifications api with the transformed data
+  Examples:
+  | type        |
+  | undertaking |

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,5 +24,10 @@ logger:
 
 api:
   disqualified-officers-data-api-key: ${DISQUALIFIED_OFFICERS_DATA_API_KEY:localhost}
-  api-url: ${API_URL:localhost}
+  api-url: ${API_URL:http://localhost:8888}
   internal-api-url: ${INTERNAL_API_URL:localhost}
+
+wiremock:
+  server:
+    port: 8888
+


### PR DESCRIPTION
This pr adds integration tests to the disqualified-officers-delta-consumer. Tests cover scenarios for natural and corporate officers with undertaking and court order disqualification types.

**Resolves:**
- DSND-716