### PR TITLE
Make integration test failures fail build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test-unit:
 
 .PHONY: test-integration
 test-integration:
-	mvn integration-test -Dskip.unit.tests=true
+	mvn integration-test -Dskip.unit.tests=true failsafe:verify
 
 .PHONY: package
 package:


### PR DESCRIPTION
This pr makes it so if the integration tests are run and fail the build fails, alerting the user via concourse.