### PR TITLE
Add transformer error handling and unit tests

### DIFF
--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/exception/RetryableErrorException.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/exception/RetryableErrorException.java
@@ -4,4 +4,8 @@ public class RetryableErrorException extends RuntimeException {
     public RetryableErrorException(String message) {
         super(message);
     }
+
+    public RetryableErrorException(String message, Exception exception) {
+        super(message, exception);
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/handler/ApiResponseHandler.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/handler/ApiResponseHandler.java
@@ -25,7 +25,7 @@ public class ApiResponseHandler {
             throw new NonRetryableErrorException(msg);
         } else if (!httpStatus.is2xxSuccessful()) {
             // any other client or server status can be retried
-            String msg = "Non-Successful 200 response received from disqualified-officers-data-api";
+            String msg = "Non-Successful response received from disqualified-officers-data-api";
             logger.errorContext(logContext, msg + ", retry", null, logMap);
             throw new RetryableErrorException(msg);
         } else {

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
@@ -19,6 +19,7 @@ import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificatio
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.delta.ChsDelta;
 import uk.gov.companieshouse.disqualifiedofficers.delta.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.disqualifiedofficers.delta.exception.RetryableErrorException;
 import uk.gov.companieshouse.disqualifiedofficers.delta.handler.ApiResponseHandler;
 import uk.gov.companieshouse.disqualifiedofficers.delta.service.api.ApiClientService;
 import uk.gov.companieshouse.disqualifiedofficers.delta.transformer.DisqualifiedOfficersApiTransformer;
@@ -71,14 +72,26 @@ public class DisqualifiedOfficersDeltaProcessor {
                 .get(0);
         if (disqualificationOfficer.getCorporateInd() != null
                     && disqualificationOfficer.getCorporateInd().equals("1")) {
-            InternalCorporateDisqualificationApi apiObject = transformer
-                    .transformCorporateDisqualification(disqualifiedOfficersDelta);
+            InternalCorporateDisqualificationApi apiObject;
+            try {
+                apiObject = transformer.transformCorporateDisqualification(
+                        disqualifiedOfficersDelta);
+            } catch (Exception ex) {
+                throw new RetryableErrorException(
+                        "Error when transforming into Api object", ex);
+            }
             //invoke disqualified officers API with Corporate method
             invokeDisqualificationsDataApi(logContext, disqualificationOfficer,
                     apiObject, logMap);
         } else {
-            InternalNaturalDisqualificationApi apiObject = transformer
-                    .transformNaturalDisqualification(disqualifiedOfficersDelta);
+            InternalNaturalDisqualificationApi apiObject;
+            try {
+                apiObject = transformer.transformNaturalDisqualification(
+                        disqualifiedOfficersDelta);
+            } catch (Exception ex) {
+                throw new RetryableErrorException(
+                        "Error when transforming into Api object", ex);
+            }
             //invoke disqualified officers API with Natural method
             invokeDisqualificationsDataApi(logContext, disqualificationOfficer,
                     apiObject, logMap);

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/handler/ApiResponseHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/handler/ApiResponseHandlerTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
 import uk.gov.companieshouse.disqualifiedofficers.delta.exception.NonRetryableErrorException;
 import uk.gov.companieshouse.disqualifiedofficers.delta.exception.RetryableErrorException;
 import uk.gov.companieshouse.logging.Logger;
@@ -22,8 +21,6 @@ class ApiResponseHandlerTest {
 
     @Mock
     private Logger logger;
-    @Mock
-    ResponseStatusException ex;
 
     @Test
     void handle200Response() throws NonRetryableErrorException, RetryableErrorException {
@@ -46,12 +43,22 @@ class ApiResponseHandlerTest {
     }
 
     @Test
+    void handle404Response() throws NonRetryableErrorException, RetryableErrorException {
+        HttpStatus httpStatus = HttpStatus.NOT_FOUND;
+        Map<String, Object> logMap = new HashMap<>();
+        assertThrows(RetryableErrorException.class, () -> apiResponseHandler.handleResponse(
+                httpStatus, "status", logMap, logger));
+        verify(logger).errorContext("status",
+                "Non-Successful response received from disqualified-officers-data-api, retry", null, logMap);
+    }
+
+    @Test
     void handle500Response() throws NonRetryableErrorException, RetryableErrorException {
         HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
         Map<String, Object> logMap = new HashMap<>();
         assertThrows(RetryableErrorException.class, () -> apiResponseHandler.handleResponse(
                 httpStatus, "status", logMap, logger));
         verify(logger).errorContext("status",
-                "Non-Successful 200 response received from disqualified-officers-data-api, retry", null, logMap);
+                "Non-Successful response received from disqualified-officers-data-api, retry", null, logMap);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersProcessorTest.java
@@ -12,6 +12,8 @@ import uk.gov.companieshouse.api.delta.*;
 import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.delta.ChsDelta;
+import uk.gov.companieshouse.disqualifiedofficers.delta.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.disqualifiedofficers.delta.exception.RetryableErrorException;
 import uk.gov.companieshouse.disqualifiedofficers.delta.service.api.ApiClientService;
 import uk.gov.companieshouse.disqualifiedofficers.delta.transformer.DisqualifiedOfficersApiTransformer;
 import uk.gov.companieshouse.disqualifiedofficers.delta.utils.TestHelper;
@@ -19,6 +21,7 @@ import uk.gov.companieshouse.logging.Logger;
 
 import java.io.IOException;
 
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -61,5 +64,28 @@ public class DisqualifiedOfficersProcessorTest {
 
         verify(transformer).transformNaturalDisqualification(expectedDelta);
         verify(apiClientService).putDisqualification("context_id", "3002276133", apiObject);
+    }
+
+    @Test
+    void When_InvalidChsDeltaMessage_Expect_NonRetryableError() {
+        Message<ChsDelta> mockChsDeltaMessage = testHelper.createInvalidChsDeltaMessage();
+        assertThrows(NonRetryableErrorException.class, ()->deltaProcessor.processDelta(mockChsDeltaMessage));
+    }
+
+    @Test
+    void When_ApiReturns500_Expect_RetryableError() throws IOException {
+        Message<ChsDelta> mockChsDeltaMessage = testHelper.createChsDeltaMessage();
+        InternalNaturalDisqualificationApi apiObject = testHelper.createDisqualificationApi();
+        final ApiResponse<Void> response = new ApiResponse<>(HttpStatus.INTERNAL_SERVER_ERROR.value(), null, null);
+        when(apiClientService.putDisqualification(any(),any(), eq(apiObject))).thenReturn(response);
+        when(transformer.transformNaturalDisqualification(any())).thenReturn(apiObject);
+        assertThrows(RetryableErrorException.class, ()->deltaProcessor.processDelta(mockChsDeltaMessage));
+    }
+
+    @Test
+    void When_Transformer_Fails_Expect_RetryableError() throws IOException {
+        Message<ChsDelta> mockChsDeltaMessage = testHelper.createBrokenChsDeltaMessage();
+        when(transformer.transformNaturalDisqualification(any())).thenCallRealMethod();
+        assertThrows(RetryableErrorException.class, ()->deltaProcessor.processDelta(mockChsDeltaMessage));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/serialization/ChsDeltaSerializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/serialization/ChsDeltaSerializerTest.java
@@ -6,9 +6,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.delta.ChsDelta;
+import uk.gov.companieshouse.disqualifiedofficers.delta.exception.NonRetryableErrorException;
 import uk.gov.companieshouse.logging.Logger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 public class ChsDeltaSerializerTest {
@@ -43,6 +45,12 @@ public class ChsDeltaSerializerTest {
         byte[] byteExample = "Example bytes".getBytes();
         byte[] serialize = serializer.serialize("", byteExample);
         assertThat(serialize).isEqualTo(byteExample);
+    }
+
+    @Test
+    void When_serialize_receives_blank_object_exception_thrown() {
+        ChsDelta payload = new ChsDelta();
+        assertThrows(NonRetryableErrorException.class, () -> serializer.serialize("",payload));
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/utils/TestHelper.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/utils/TestHelper.java
@@ -26,17 +26,7 @@ public class TestHelper {
                 ClassLoader.getSystemClassLoader().getResourceAsStream("disqualified-officers-delta-example.json"));
         String data = FileCopyUtils.copyToString(exampleJsonPayload);
 
-        ChsDelta mockChsDelta = ChsDelta.newBuilder()
-                .setData(data)
-                .setContextId("context_id")
-                .setAttempt(1)
-                .build();
-
-        return MessageBuilder
-                .withPayload(mockChsDelta)
-                .setHeader(KafkaHeaders.RECEIVED_TOPIC, "test")
-                .setHeader("DISQUALIFIED_OFFICERS_DELTA_RETRY_COUNT", 1)
-                .build();
+        return buildMessage(data);
     }
 
     public InternalNaturalDisqualificationApi createDisqualificationApi() {
@@ -116,5 +106,30 @@ public class TestHelper {
         ProducerRecord<String, Object> record = new ProducerRecord<>(topic, 1,1L ,null, recordObj, headers);
 
         return record;
+    }
+
+    public Message<ChsDelta> createInvalidChsDeltaMessage() {
+        return buildMessage("This is some invalid data");
+    }
+
+    public Message<ChsDelta> createBrokenChsDeltaMessage() throws IOException {
+        InputStreamReader exampleJsonPayload = new InputStreamReader(
+                ClassLoader.getSystemClassLoader().getResourceAsStream("invalid-disqualified-officers-delta-example.json"));
+        String data = FileCopyUtils.copyToString(exampleJsonPayload);
+        return buildMessage(data);
+    }
+
+    private Message<ChsDelta> buildMessage(String data) {
+        ChsDelta mockChsDelta = ChsDelta.newBuilder()
+                .setData(data)
+                .setContextId("context_id")
+                .setAttempt(1)
+                .build();
+
+        return MessageBuilder
+                .withPayload(mockChsDelta)
+                .setHeader(KafkaHeaders.RECEIVED_TOPIC, "test")
+                .setHeader("DISQUALIFIED_OFFICERS_DELTA_RETRY_COUNT", 1)
+                .build();
     }
 }

--- a/src/test/resources/invalid-disqualified-officers-delta-example.json
+++ b/src/test/resources/invalid-disqualified-officers-delta-example.json
@@ -1,0 +1,13 @@
+{
+  "disqualified_officer": [{
+    "officer_disq_id": "3000035941",
+    "external_number": "168544120001",
+    "officer_id": "3002276133",
+    "officer_detail_id": "3002842206",
+    "date_of_birth": "19770718",
+    "forename": "Jason",
+    "middle_name": "John",
+    "surname": "PISTOLAS",
+    "nationality": "British"
+  }]
+  }


### PR DESCRIPTION
This PR adds RetryableError exception handling around the transformer and adds unit tests to check all Retryable and NonRetryable error scenarios according to the spec sheet.

**Resolves:**
- DSND-660