### PR TITLE
Add retry and error delete integration tests

### DIFF
--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
@@ -133,6 +133,26 @@ public class CommonSteps {
         countDown();
     }
 
+    @When("the consumer receives an invalid delete payload")
+    public void theConsumerReceivesInvalidDelete() throws Exception {
+        configureWiremock();
+        stubDeleteDisqualification(200);
+        ChsDelta delta = new ChsDelta("invalid", 1, "1", true);
+        kafkaTemplate.send(mainTopic, delta);
+
+        countDown();
+    }
+
+    @When("^the consumer receives a delete message but the data api returns a (\\d*)$")
+    public void theConsumerReceivesDeleteMessageButDataApiReturns(int responseCode) throws Exception{
+        configureWiremock();
+        stubDeleteDisqualification(responseCode);
+        ChsDelta delta = new ChsDelta(TestData.getDeleteData(), 1, "1", true);
+        kafkaTemplate.send(mainTopic, delta);
+
+        countDown();
+    }
+
     @Then("a DELETE request is sent to the disqualifications api with the encoded Id")
     public void deleteRequestIsSent() {
         verify(1, deleteRequestedFor(urlMatching(

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
@@ -136,7 +136,6 @@ public class CommonSteps {
     @When("the consumer receives an invalid delete payload")
     public void theConsumerReceivesInvalidDelete() throws Exception {
         configureWiremock();
-        stubDeleteDisqualification(200);
         ChsDelta delta = new ChsDelta("invalid", 1, "1", true);
         kafkaTemplate.send(mainTopic, delta);
 

--- a/src/itest/resources/features/Delete.feature
+++ b/src/itest/resources/features/Delete.feature
@@ -4,3 +4,22 @@ Feature: Delete
     Given the application is running
     When the consumer receives a delete payload
     Then a DELETE request is sent to the disqualifications api with the encoded Id
+
+  Scenario: send DELETE with invalid JSON
+    Given the application is running
+    When the consumer receives an invalid delete payload
+    Then the message should be moved to topic disqualified-officers-delta-invalid
+
+  Scenario: send DELETE with 400 from data api
+    Given the application is running
+    When the consumer receives a delete message but the data api returns a 400
+    Then the message should be moved to topic disqualified-officers-delta-invalid
+
+  Scenario Outline: send DELETE with retryable response from data api
+    Given the application is running
+    When the consumer receives a delete message but the data api returns a <code>
+    Then the message should retry 3 times and then error
+    Examples:
+    | code |
+    | 404  |
+    | 503  |


### PR DESCRIPTION
This pr adds scenarios to the integration tests for delete retryable and non retrayable errors. 
Scenarios covered: 
- Invalid JSON - Non retryable
- Data api returns 400 - Non retryable
- Data api returns 404 - retryable
- Data api returns 503 - retryable

**Resolves:**
- DSND-1039