### PR TITLE
Add logging to delta processor

### DIFF
--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
@@ -68,7 +68,7 @@ public class DisqualifiedOfficersDeltaProcessor {
                     "Error when extracting disqualified-officers delta", ex);
         }
 
-        logger.info(String.format("DisqualificationDelta extraced for context ID [%s]"
+        logger.info(String.format("DisqualificationDelta extracted for context ID [%s]"
                 + " Kafka message: [%s]", logContext, disqualifiedOfficersDelta));
 
         DisqualificationOfficer disqualificationOfficer = disqualifiedOfficersDelta
@@ -128,7 +128,7 @@ public class DisqualifiedOfficersDeltaProcessor {
                     "Error when extracting disqualified-officers delete delta", ex);
         }
 
-        logger.info(String.format("DisqualificationDeleteDelta extraced for context ID" 
+        logger.info(String.format("DisqualificationDeleteDelta extracted for context ID" 
                 + " [%s] Kafka message: [%s]", logContext, disqualifiedOfficersDelete));
         officerId = MapperUtils.encode(disqualifiedOfficersDelete.getOfficerId());
         logger.info(String.format("Performing a DELETE for officer id: [%s]", officerId));

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
@@ -68,7 +68,7 @@ public class DisqualifiedOfficersDeltaProcessor {
                     "Error when extracting disqualified-officers delta", ex);
         }
 
-        logger.trace(String.format("DisqualificationDelta extraced for context ID %s " + "Kafka message: %s", logContext, disqualifiedOfficersDelta));
+        logger.trace(String.format("DisqualificationDelta extraced for context ID [%s] Kafka message: [%s]", logContext, disqualifiedOfficersDelta));
 
         DisqualificationOfficer disqualificationOfficer = disqualifiedOfficersDelta
                 .getDisqualifiedOfficer()
@@ -84,7 +84,7 @@ public class DisqualifiedOfficersDeltaProcessor {
                         "Error when transforming into Api object", ex);
             }
 
-            logger.trace(String.format("Message with context ID: %s successfully transformed into CorporateDisqualificationAPI object",
+            logger.trace(String.format("Message with context ID: [%s] successfully transformed into CorporateDisqualificationAPI object",
                 logContext));
 
             //invoke disqualified officers API with Corporate method
@@ -100,7 +100,7 @@ public class DisqualifiedOfficersDeltaProcessor {
                         "Error when transforming into Api object", ex);
             }
 
-            logger.trace(String.format("Message with context ID: %s successfully transformed into NaturalDisqualificationAPI object",
+            logger.trace(String.format("Message with context ID: [%s] successfully transformed into NaturalDisqualificationAPI object",
                 logContext));
 
             //invoke disqualified officers API with Natural method
@@ -127,9 +127,9 @@ public class DisqualifiedOfficersDeltaProcessor {
                     "Error when extracting disqualified-officers delete delta", ex);
         }
 
-        logger.trace(String.format("DisqualificationDeleteDelta extraced for context ID %s " + "Kafka message: %s", logContext, disqualifiedOfficersDelete));
+        logger.trace(String.format("DisqualificationDeleteDelta extraced for context ID [%s] Kafka message: [%s]", logContext, disqualifiedOfficersDelete));
         officerId = MapperUtils.encode(disqualifiedOfficersDelete.getOfficerId());
-        logger.trace(String.format("Performing a DELETE for officer id: %s", officerId));
+        logger.trace(String.format("Performing a DELETE for officer id: [%s]", officerId));
         apiClientService.deleteDisqualification(logContext, officerId);
     }
 

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
@@ -67,6 +67,9 @@ public class DisqualifiedOfficersDeltaProcessor {
             throw new NonRetryableErrorException(
                     "Error when extracting disqualified-officers delta", ex);
         }
+
+        logger.trace(String.format("DisqualificationDelta extraced for context ID %s " + "Kafka message: %s", logContext, disqualifiedOfficersDelta));
+
         DisqualificationOfficer disqualificationOfficer = disqualifiedOfficersDelta
                 .getDisqualifiedOfficer()
                 .get(0);
@@ -80,6 +83,10 @@ public class DisqualifiedOfficersDeltaProcessor {
                 throw new RetryableErrorException(
                         "Error when transforming into Api object", ex);
             }
+
+            logger.trace(String.format("Message with context ID: %s successfully transformed into CorporateDisqualificationAPI object",
+                logContext));
+
             //invoke disqualified officers API with Corporate method
             invokeDisqualificationsDataApi(logContext, disqualificationOfficer,
                     apiObject, logMap);
@@ -92,6 +99,10 @@ public class DisqualifiedOfficersDeltaProcessor {
                 throw new RetryableErrorException(
                         "Error when transforming into Api object", ex);
             }
+
+            logger.trace(String.format("Message with context ID: %s successfully transformed into NaturalDisqualificationAPI object",
+                logContext));
+
             //invoke disqualified officers API with Natural method
             invokeDisqualificationsDataApi(logContext, disqualificationOfficer,
                     apiObject, logMap);
@@ -115,7 +126,10 @@ public class DisqualifiedOfficersDeltaProcessor {
             throw new NonRetryableErrorException(
                     "Error when extracting disqualified-officers delete delta", ex);
         }
+
+        logger.trace(String.format("DisqualificationDeleteDelta extraced for context ID %s " + "Kafka message: %s", logContext, disqualifiedOfficersDelete));
         officerId = MapperUtils.encode(disqualifiedOfficersDelete.getOfficerId());
+        logger.trace(String.format("Performing a DELETE for officer id: %s", officerId));
         apiClientService.deleteDisqualification(logContext, officerId);
     }
 

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
@@ -68,7 +68,8 @@ public class DisqualifiedOfficersDeltaProcessor {
                     "Error when extracting disqualified-officers delta", ex);
         }
 
-        logger.trace(String.format("DisqualificationDelta extraced for context ID [%s] Kafka message: [%s]", logContext, disqualifiedOfficersDelta));
+        logger.trace(String.format("DisqualificationDelta extraced for context ID [%s]"
+                + " Kafka message: [%s]", logContext, disqualifiedOfficersDelta));
 
         DisqualificationOfficer disqualificationOfficer = disqualifiedOfficersDelta
                 .getDisqualifiedOfficer()
@@ -84,8 +85,8 @@ public class DisqualifiedOfficersDeltaProcessor {
                         "Error when transforming into Api object", ex);
             }
 
-            logger.trace(String.format("Message with context ID: [%s] successfully transformed into CorporateDisqualificationAPI object",
-                logContext));
+            logger.trace(String.format("Message with context ID: [%s] successfully transformed into"
+                    + " CorporateDisqualificationAPI object", logContext));
 
             //invoke disqualified officers API with Corporate method
             invokeDisqualificationsDataApi(logContext, disqualificationOfficer,
@@ -100,8 +101,8 @@ public class DisqualifiedOfficersDeltaProcessor {
                         "Error when transforming into Api object", ex);
             }
 
-            logger.trace(String.format("Message with context ID: [%s] successfully transformed into NaturalDisqualificationAPI object",
-                logContext));
+            logger.trace(String.format("Message with context ID: [%s] successfully" 
+                    + " transformed into NaturalDisqualificationAPI object", logContext));
 
             //invoke disqualified officers API with Natural method
             invokeDisqualificationsDataApi(logContext, disqualificationOfficer,
@@ -127,7 +128,8 @@ public class DisqualifiedOfficersDeltaProcessor {
                     "Error when extracting disqualified-officers delete delta", ex);
         }
 
-        logger.trace(String.format("DisqualificationDeleteDelta extraced for context ID [%s] Kafka message: [%s]", logContext, disqualifiedOfficersDelete));
+        logger.trace(String.format("DisqualificationDeleteDelta extraced for context ID" 
+                + " [%s] Kafka message: [%s]", logContext, disqualifiedOfficersDelete));
         officerId = MapperUtils.encode(disqualifiedOfficersDelete.getOfficerId());
         logger.trace(String.format("Performing a DELETE for officer id: [%s]", officerId));
         apiClientService.deleteDisqualification(logContext, officerId);

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
@@ -68,7 +68,7 @@ public class DisqualifiedOfficersDeltaProcessor {
                     "Error when extracting disqualified-officers delta", ex);
         }
 
-        logger.trace(String.format("DisqualificationDelta extraced for context ID [%s]"
+        logger.info(String.format("DisqualificationDelta extraced for context ID [%s]"
                 + " Kafka message: [%s]", logContext, disqualifiedOfficersDelta));
 
         DisqualificationOfficer disqualificationOfficer = disqualifiedOfficersDelta
@@ -85,7 +85,7 @@ public class DisqualifiedOfficersDeltaProcessor {
                         "Error when transforming into Api object", ex);
             }
 
-            logger.trace(String.format("Message with context ID: [%s] successfully transformed into"
+            logger.info(String.format("Message with context ID: [%s] successfully transformed into"
                     + " CorporateDisqualificationAPI object", logContext));
 
             //invoke disqualified officers API with Corporate method
@@ -101,7 +101,7 @@ public class DisqualifiedOfficersDeltaProcessor {
                         "Error when transforming into Api object", ex);
             }
 
-            logger.trace(String.format("Message with context ID: [%s] successfully" 
+            logger.info(String.format("Message with context ID: [%s] successfully" 
                     + " transformed into NaturalDisqualificationAPI object", logContext));
 
             //invoke disqualified officers API with Natural method
@@ -128,10 +128,10 @@ public class DisqualifiedOfficersDeltaProcessor {
                     "Error when extracting disqualified-officers delete delta", ex);
         }
 
-        logger.trace(String.format("DisqualificationDeleteDelta extraced for context ID" 
+        logger.info(String.format("DisqualificationDeleteDelta extraced for context ID" 
                 + " [%s] Kafka message: [%s]", logContext, disqualifiedOfficersDelete));
         officerId = MapperUtils.encode(disqualifiedOfficersDelete.getOfficerId());
-        logger.trace(String.format("Performing a DELETE for officer id: [%s]", officerId));
+        logger.info(String.format("Performing a DELETE for officer id: [%s]", officerId));
         apiClientService.deleteDisqualification(logContext, officerId);
     }
 


### PR DESCRIPTION
This PR is to add logging to the disqualified officer delta processor so that flow of code can be monitored in the logs.

**Resolves**
- DSND-1114