### PR TITLE
Add kafka topic config

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ disqualified-officers:
     group-id: disqualified-officers-delta-consumer
     retry-attempts: 4
     backoff-delay: 100
-    topic: disqualified-officers-delta
+    topic: ${DISQUALIFIED_OFFICERS_DELTA_TOPIC:disqualified-officers-delta}
 
 logger:
   namespace: disqualified-officers-delta-consumer


### PR DESCRIPTION
This pr changes the kafka topic config to be settable in configs. This is so that it can use the common kafka 3 server for dev environments