### PR TITLE
PAS-388 Add mappings for new disqualification type: Sanction

### DIFF
--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/DisqualificationMapper.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/DisqualificationMapper.java
@@ -71,6 +71,7 @@ public interface DisqualificationMapper {
         disqualifyingLaw.put("CDDA", "company-directors-disqualification-act-1986");
         disqualifyingLaw.put("CDDO",
                 "company-directors-disqualification-northern-ireland-order-2002");
+        disqualifyingLaw.put("SAMLA", "sanctions-anti-money-laundering-act-2018");
 
         HashMap<String, String> descriptionIdentifier = MapperUtils.createIdentifierHashMap();
 
@@ -79,7 +80,10 @@ public interface DisqualificationMapper {
         reason.put("act", disqualifyingLaw.get(sectionParts[0]));
         reason.put("description_identifier", descriptionIdentifier.get(sectionParts[2]));
 
-        String disqualificationReference = sectionParts[0].equals("CDDA") ? "section" : "article";
+        String disqualificationReference = "article";
+        if (sectionParts[0].equals("CDDA") || sectionParts[0].equals("SAMLA")) {
+            disqualificationReference = "section";
+        }
 
         reason.put(disqualificationReference, sectionParts[2].substring(1));
 
@@ -99,6 +103,7 @@ public interface DisqualificationMapper {
         HashMap<String, String> disqualificationType = new HashMap<>();
         disqualificationType.put("ORDER", "court-order");
         disqualificationType.put("UNDERTAKING", "undertaking");
+        disqualificationType.put("SANCTION", "sanction");
         target.setDisqualificationType(disqualificationType.get(sourceDisq.getDisqType()));
     }
 
@@ -116,7 +121,7 @@ public interface DisqualificationMapper {
         if (sourceDisq.getDisqType().equals("ORDER")) {
             target.setCourtName(sourceDisq.getCourtName());
             target.setHeardOn(LocalDate.parse(sourceDisq.getHearingDate(), formater));
-        } else {
+        } else if (sourceDisq.getDisqType().equals("UNDERTAKING")) {
             target.setUndertakenOn(LocalDate.parse(sourceDisq.getHearingDate(), formater));
         }
     }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/MapperUtils.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/MapperUtils.java
@@ -73,6 +73,7 @@ public final class MapperUtils {
         descriptionIdentifier.put("S9B", 
                 "competition-and-markets-authority-disqualification-undertaking");
         descriptionIdentifier.put("S10", "participation-in-wrongful-trading");
+        descriptionIdentifier.put("S3A", "director-disqualification-sanctions");
 
         return descriptionIdentifier;
     }


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/PAS-388

The following mappings are added:
- A new disqualification type: SANCTION
- A new made under section: SAMLA 2018 S3A

Add key/value pairs for the above so they can be displayed correctly within the register of disqualifications.