### PR TITLE
DSND-3109: Add delta at to delete test data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <ch-kafka.version>3.0.3</ch-kafka.version>
         <structured-logging.version>3.0.9</structured-logging.version>
         <kafka-models.version>3.0.8</kafka-models.version>
-        <private-api-sdk-java.version>4.0.99</private-api-sdk-java.version>
+        <private-api-sdk-java.version>4.0.210</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
         <jib-maven-plugin.version>3.4.2</jib-maven-plugin.version>
         <springfox-boot-starter.version>3.0.0</springfox-boot-starter.version>

--- a/src/itest/resources/data/delete_disqualification.json
+++ b/src/itest/resources/data/delete_disqualification.json
@@ -1,4 +1,5 @@
 {
   "action": "DELETE",
-  "officer_id": "1234567890"
+  "officer_id": "1234567890",
+  "delta_at": "20230724093435661593"
 }

--- a/src/test/resources/disqualified-officers-delete-example.json
+++ b/src/test/resources/disqualified-officers-delete-example.json
@@ -1,4 +1,5 @@
 {
   "action": "DELETE",
-  "officer_id": "1234567890"
+  "officer_id": "1234567890",
+  "delta_at": "20230724093435661593"
 }


### PR DESCRIPTION
This PR updates the tests to ensure the consumer can handle a delta_at field on an incoming delete delta.

[DSND-3109](https://companieshouse.atlassian.net/browse/DSND-3109)

[DSND-3109]: https://companieshouse.atlassian.net/browse/DSND-3109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ