### PR TITLE
DSND-3119: Send delete with delta at

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ build:
 	cp ./target/$(artifact_name)-$(version).jar ./$(artifact_name).jar
 
 .PHONY: test
-test: test-integration test-unit
+test: clean test-integration test-unit
 
 .PHONY: test-unit
 test-unit:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ test-unit            Run unit tests
 
 ```
 
+## Building the docker image
+```bash
+mvn compile jib:dockerBuild
+```
+
 ## Endpoints
 | URL | Description |
 | --- | ----------- |

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
             <version>2.10.0</version>
             <scope>test</scope>
         </dependency>
-<!--        Transitive dependencies start here-->
+<!--        Transitive dependencies end here-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,27 +18,30 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>
         <main.class>uk.gov.companieshouse.disqualifiedofficers.delta.DisqualifiedOfficersDeltaConsumerApplication</main.class>
-        <map-struct.version>1.6.0</map-struct.version>
-        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
+        <spring.boot.version>3.3.4</spring.boot.version>
+        <map-struct.version>1.6.2</map-struct.version>
+        <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
         <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
-        <maven-failsafe-plugin.version>3.4.0</maven-failsafe-plugin.version>
+        <maven-failsafe-plugin.version>3.5.1</maven-failsafe-plugin.version>
         <ch-kafka.version>3.0.3</ch-kafka.version>
-        <structured-logging.version>3.0.9</structured-logging.version>
+        <structured-logging.version>3.0.20</structured-logging.version>
         <kafka-models.version>3.0.8</kafka-models.version>
         <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
-        <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
+        <api-sdk-manager-java-library.version>3.0.6</api-sdk-manager-java-library.version>
         <jib-maven-plugin.version>3.4.2</jib-maven-plugin.version>
         <springfox-boot-starter.version>3.0.0</springfox-boot-starter.version>
-        <maven-checkstyle-plugin.version>3.5.0</maven-checkstyle-plugin.version>
-        <checkstyle.version>10.18.1</checkstyle.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+        <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
 
         <!-- Tests -->
-        <io-cucumber.version>7.18.1</io-cucumber.version>
+        <io-cucumber.version>7.20.1</io-cucumber.version>
         <skip.integration.tests>false</skip.integration.tests>
         <skip.unit.tests>false</skip.unit.tests>
         <assertj-core.version>3.26.3</assertj-core.version>
-        <wiremock.version>3.9.1</wiremock.version>
-        <testcontainers.version>1.20.1</testcontainers.version>
+        <wiremock.version>3.9.2</wiremock.version>
+        <testcontainers.version>1.20.3</testcontainers.version>
 
         <!--sonar configuration-->
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
@@ -51,11 +54,6 @@
             ${project.basedir}/target/site/jacoco-it/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <sonar.jacoco.reports>${project.basedir}/target/site</sonar.jacoco.reports>
-        <spring.boot.version>3.3.3</spring.boot.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
-        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-        <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -71,6 +69,19 @@
     </dependencyManagement>
 
     <dependencies>
+<!--        Transitive dependencies start here-->
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>1.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-core</artifactId>
+            <version>2.10.0</version>
+            <scope>test</scope>
+        </dependency>
+<!--        Transitive dependencies start here-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
@@ -246,28 +257,6 @@
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>${maven-checkstyle-plugin.version}</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>com.puppycrawl.tools</groupId>
-                            <artifactId>checkstyle</artifactId>
-                            <version>${checkstyle.version}</version>
-                            <exclusions>
-                                <exclusion>
-                                    <groupId>org.xmlresolver</groupId>
-                                    <artifactId>xmlresolver</artifactId>
-                                </exclusion>
-                            </exclusions>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-            </plugins>
-        </pluginManagement>
 
         <plugins>
             <plugin>
@@ -418,27 +407,6 @@
                     </annotationProcessorPaths>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>${maven-checkstyle-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <violationSeverity>warning</violationSeverity>
-                    <logViolationsToConsole>true</logViolationsToConsole>
-                    <failsOnError>true</failsOnError>
-                    <failOnViolation>true</failOnViolation>
-                    <configLocation>src/main/resources/companieshouse_checks.xml</configLocation>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>
         <main.class>uk.gov.companieshouse.disqualifiedofficers.delta.DisqualifiedOfficersDeltaConsumerApplication</main.class>
-        <spring.boot.version>3.3.4</spring.boot.version>
+        <spring.boot.version>3.3.5</spring.boot.version>
         <map-struct.version>1.6.2</map-struct.version>
         <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
         <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <ch-kafka.version>3.0.3</ch-kafka.version>
         <structured-logging.version>3.0.20</structured-logging.version>
         <kafka-models.version>3.0.8</kafka-models.version>
-        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
+        <private-api-sdk-java.version>4.0.234</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.6</api-sdk-manager-java-library.version>
         <jib-maven-plugin.version>3.4.2</jib-maven-plugin.version>
         <springfox-boot-starter.version>3.0.0</springfox-boot-starter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <ch-kafka.version>3.0.3</ch-kafka.version>
         <structured-logging.version>3.0.9</structured-logging.version>
         <kafka-models.version>3.0.8</kafka-models.version>
-        <private-api-sdk-java.version>4.0.211</private-api-sdk-java.version>
+        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
         <jib-maven-plugin.version>3.4.2</jib-maven-plugin.version>
         <springfox-boot-starter.version>3.0.0</springfox-boot-starter.version>

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
@@ -155,7 +155,7 @@ public class CommonSteps {
     @Then("a DELETE request is sent to the disqualifications api with the encoded Id")
     public void deleteRequestIsSent() {
         verify(1, deleteRequestedFor(urlMatching(
-                "/disqualified-officers/delete/1kETe9SJWIp9OlvZgO1xmjyt5_s/internal")));
+                "/disqualified-officers/natural/1kETe9SJWIp9OlvZgO1xmjyt5_s/internal")));
     }
 
     @After

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
@@ -180,7 +180,7 @@ public class CommonSteps {
     }
 
     private void stubDeleteDisqualification(int responseCode) {
-        stubFor(delete(urlEqualTo("/disqualified-officers/delete/1kETe9SJWIp9OlvZgO1xmjyt5_s/internal"))
+        stubFor(delete(urlEqualTo("/disqualified-officers/natural/1kETe9SJWIp9OlvZgO1xmjyt5_s/internal"))
                 .willReturn(aResponse().withStatus(responseCode)));
     }
 

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualificationType.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualificationType.java
@@ -1,0 +1,30 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.processor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum DisqualificationType {
+
+    CORPORATE("corporate"),
+    NATURAL("natural");
+
+    private static final Map<String, DisqualificationType> BY_OFFICER_TYPE = new HashMap<>();
+
+    static {
+        BY_OFFICER_TYPE.put("1", CORPORATE);
+    }
+
+    private final String type;
+
+    DisqualificationType(String type) {
+        this.type = type;
+    }
+
+    public static DisqualificationType getTypeFromCorporateInd(final String corporateInd) {
+        return BY_OFFICER_TYPE.getOrDefault(corporateInd, NATURAL);
+    }
+
+    public String getTypeAsString() {
+        return type;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
@@ -122,7 +122,7 @@ public class DisqualifiedOfficersDeltaProcessor {
                 + " [%s] Kafka message: [%s]", logContext, disqualifiedOfficersDelete));
         officerId = MapperUtils.encode(disqualifiedOfficersDelete.getOfficerId());
         logger.info(String.format("Performing a DELETE for officer id: [%s]", officerId));
-        apiClientService.deleteDisqualification(logContext, officerId);
+        apiClientService.deleteDisqualification(logContext, officerId, disqualifiedOfficersDelete.getDeltaAt());
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
@@ -28,8 +28,9 @@ public class DisqualifiedOfficersDeltaProcessor {
 
     /**
      * Constructor for the delta processor.
-     * @param transformer transforms the data from delta to api object through mapstruct
-     * @param logger logs out messages to the app logs
+     *
+     * @param transformer      transforms the data from delta to api object through mapstruct
+     * @param logger           logs out messages to the app logs
      * @param apiClientService handles PUT request to the disqualified data API
      */
     @Autowired
@@ -65,7 +66,7 @@ public class DisqualifiedOfficersDeltaProcessor {
                 .getDisqualifiedOfficer()
                 .getFirst();
         if (disqualificationOfficer.getCorporateInd() != null
-                    && disqualificationOfficer.getCorporateInd().equals("1")) {
+                && disqualificationOfficer.getCorporateInd().equals("1")) {
             InternalCorporateDisqualificationApi apiObject;
             try {
                 apiObject = transformer.transformCorporateDisqualification(
@@ -91,7 +92,7 @@ public class DisqualifiedOfficersDeltaProcessor {
                         "Error when transforming into Api object", ex);
             }
 
-            logger.info(String.format("Message with context ID: [%s] successfully" 
+            logger.info(String.format("Message with context ID: [%s] successfully"
                     + " transformed into NaturalDisqualificationAPI object", logContext));
 
             //invoke disqualified officers API with Natural method
@@ -117,21 +118,26 @@ public class DisqualifiedOfficersDeltaProcessor {
             throw new NonRetryableErrorException(
                     "Error when extracting disqualified-officers delete delta", ex);
         }
-
-        logger.info(String.format("DisqualificationDeleteDelta extracted for context ID" 
+        logger.info(String.format("DisqualificationDeleteDelta extracted for context ID"
                 + " [%s] Kafka message: [%s]", logContext, disqualifiedOfficersDelete));
+
         officerId = MapperUtils.encode(disqualifiedOfficersDelete.getOfficerId());
         logger.info(String.format("Performing a DELETE for officer id: [%s]", officerId));
-        apiClientService.deleteDisqualification(logContext, officerId, disqualifiedOfficersDelete.getDeltaAt());
+
+        apiClientService.deleteDisqualification(
+                logContext,
+                officerId,
+                disqualifiedOfficersDelete.getDeltaAt(),
+                DisqualificationType.getTypeFromCorporateInd(disqualifiedOfficersDelete.getCorporateInd()));
     }
 
     /**
      * Invoke Disqualifications Data API.
      */
-    private void invokeDisqualificationsDataApi(final String logContext, 
-                        DisqualificationOfficer disqualification,
-                        InternalNaturalDisqualificationApi internalDisqualificationApi,
-                        final Map<String, Object> logMap) {
+    private void invokeDisqualificationsDataApi(final String logContext,
+            DisqualificationOfficer disqualification,
+            InternalNaturalDisqualificationApi internalDisqualificationApi,
+            final Map<String, Object> logMap) {
         logger.infoContext(
                 logContext,
                 String.format("Process disqualification for officer with id [%s]",
@@ -145,9 +151,9 @@ public class DisqualifiedOfficersDeltaProcessor {
     }
 
     private void invokeDisqualificationsDataApi(final String logContext,
-                        DisqualificationOfficer disqualification,
-                        InternalCorporateDisqualificationApi internalDisqualificationApi,
-                        final Map<String, Object> logMap) {
+            DisqualificationOfficer disqualification,
+            InternalCorporateDisqualificationApi internalDisqualificationApi,
+            final Map<String, Object> logMap) {
         logger.infoContext(
                 logContext,
                 String.format("Process disqualification for officer with id [%s]",

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientService.java
@@ -30,5 +30,5 @@ public interface ApiClientService {
     /**
      * Delete disqualification.
      */
-    ApiResponse<Void> deleteDisqualification(final String log, final String officerId);
+    ApiResponse<Void> deleteDisqualification(final String log, final String officerId, final String deltaAt);
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientService.java
@@ -4,11 +4,11 @@ import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
 import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.disqualifiedofficers.delta.processor.DisqualificationType;
 
 /**
- * The {@code ApiClientService} interface provides an abstraction that can be
- * used when testing {@code ApiClientManager} static methods, without imposing
- * the use of a test framework that supports mocking of static methods.
+ * The {@code ApiClientService} interface provides an abstraction that can be used when testing {@code ApiClientManager}
+ * static methods, without imposing the use of a test framework that supports mocking of static methods.
  */
 public interface ApiClientService {
 
@@ -30,5 +30,6 @@ public interface ApiClientService {
     /**
      * Delete disqualification.
      */
-    ApiResponse<Void> deleteDisqualification(final String log, final String officerId, final String deltaAt);
+    ApiResponse<Void> deleteDisqualification(final String log, final String officerId, final String deltaAt,
+            DisqualificationType type);
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientServiceImpl.java
@@ -12,6 +12,7 @@ import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificatio
 import uk.gov.companieshouse.api.http.ApiKeyHttpClient;
 import uk.gov.companieshouse.api.http.HttpClient;
 import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.disqualifiedofficers.delta.processor.DisqualificationType;
 import uk.gov.companieshouse.logging.Logger;
 
 
@@ -57,7 +58,7 @@ public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements Ap
 
     @Override
     public ApiResponse<Void> putDisqualification(final String log, final String officerId,
-                            InternalNaturalDisqualificationApi internalDisqualificationApi) {
+            InternalNaturalDisqualificationApi internalDisqualificationApi) {
         final String uri = String.format("/disqualified-officers/natural/%s/internal", officerId);
 
         Map<String, Object> logMap = createLogMap(officerId, "PUT", uri);
@@ -71,7 +72,7 @@ public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements Ap
 
     @Override
     public ApiResponse<Void> putDisqualification(final String log, final String officerId,
-                            InternalCorporateDisqualificationApi internalDisqualificationApi) {
+            InternalCorporateDisqualificationApi internalDisqualificationApi) {
         final String uri = String.format("/disqualified-officers/corporate/%s/internal", officerId);
 
         Map<String, Object> logMap = createLogMap(officerId, "PUT", uri);
@@ -87,11 +88,11 @@ public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements Ap
     public ApiResponse<Void> deleteDisqualification(
             final String log,
             final String officerId,
-            final String deltaAt) {
-        final String uri =
-                String.format("/disqualified-officers/delete/%s/internal", officerId);
+            final String deltaAt,
+            DisqualificationType type) {
+        final String uri = "/disqualified-officers/%s/%s/internal".formatted(type.getTypeAsString(), officerId);
 
-        Map<String,Object> logMap = createLogMap(officerId,"DELETE", uri);
+        Map<String, Object> logMap = createLogMap(officerId, "DELETE", uri);
         logger.infoContext(log, String.format("DELETE %s", uri), logMap);
 
         return executeOp(log, "deleteDisqualification", uri,

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientServiceImpl.java
@@ -86,7 +86,8 @@ public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements Ap
     @Override
     public ApiResponse<Void> deleteDisqualification(
             final String log,
-            final String officerId) {
+            final String officerId,
+            final String deltaAt) {
         final String uri =
                 String.format("/disqualified-officers/delete/%s/internal", officerId);
 
@@ -95,7 +96,7 @@ public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements Ap
 
         return executeOp(log, "deleteDisqualification", uri,
                 getApiClient(log).privateDisqualificationResourceHandler()
-                        .deleteDisqualification(uri));
+                        .deleteDisqualification(uri, deltaAt));
     }
 
     private Map<String, Object> createLogMap(String officerId, String method, String path) {

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersProcessorTest.java
@@ -96,11 +96,11 @@ class DisqualifiedOfficersProcessorTest {
         final ApiResponse<Void> response = new ApiResponse<>(HttpStatus.OK.value(), null, null);
         String encodedId = MapperUtils.encode("1234567890");
 
-        when(apiClientService.deleteDisqualification(eq("context_id"), eq(encodedId), anyString())).thenReturn(response);
+        when(apiClientService.deleteDisqualification(eq("context_id"), eq(encodedId), anyString(), any())).thenReturn(response);
 
         deltaProcessor.processDelete(mockChsDeltaMessage);
 
-        verify(apiClientService).deleteDisqualification(eq("context_id"), eq(encodedId), anyString());
+        verify(apiClientService).deleteDisqualification(eq("context_id"), eq(encodedId), anyString(), any());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersProcessorTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -95,11 +96,11 @@ class DisqualifiedOfficersProcessorTest {
         final ApiResponse<Void> response = new ApiResponse<>(HttpStatus.OK.value(), null, null);
         String encodedId = MapperUtils.encode("1234567890");
 
-        when(apiClientService.deleteDisqualification("context_id", encodedId)).thenReturn(response);
+        when(apiClientService.deleteDisqualification(eq("context_id"), eq(encodedId), anyString())).thenReturn(response);
 
         deltaProcessor.processDelete(mockChsDeltaMessage);
 
-        verify(apiClientService).deleteDisqualification("context_id", encodedId);
+        verify(apiClientService).deleteDisqualification(eq("context_id"), eq(encodedId), anyString());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientServiceImplTest.java
@@ -20,6 +20,7 @@ import uk.gov.companieshouse.api.handler.delta.disqualification.request.PrivateC
 import uk.gov.companieshouse.api.handler.delta.disqualification.request.PrivateDisqualificationDelete;
 import uk.gov.companieshouse.api.handler.delta.disqualification.request.PrivateNaturalDisqualificationUpsert;
 import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.disqualifiedofficers.delta.processor.DisqualificationType;
 import uk.gov.companieshouse.logging.Logger;
 
 
@@ -83,10 +84,10 @@ class ApiClientServiceImplTest {
                 any(PrivateDisqualificationDelete.class));
 
         apiClientServiceSpy.deleteDisqualification(
-                "context_id", "officer_id", DELTA_AT);
+                "context_id", "officer_id", DELTA_AT, DisqualificationType.NATURAL);
 
         verify(apiClientServiceSpy).executeOp(eq("context_id"), eq("deleteDisqualification"),
-                eq("/disqualified-officers/delete/officer_id/internal"),
+                eq("/disqualified-officers/natural/officer_id/internal"),
                 any(PrivateDisqualificationDelete.class));
     }
 

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/ApiClientServiceImplTest.java
@@ -1,43 +1,38 @@
 package uk.gov.companieshouse.disqualifiedofficers.delta.service.api;
 
-import org.junit.jupiter.api.BeforeEach;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.util.ReflectionTestUtils;
-import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
+import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
+import uk.gov.companieshouse.api.handler.delta.disqualification.request.PrivateCorporateDisqualificationUpsert;
 import uk.gov.companieshouse.api.handler.delta.disqualification.request.PrivateDisqualificationDelete;
 import uk.gov.companieshouse.api.handler.delta.disqualification.request.PrivateNaturalDisqualificationUpsert;
-import uk.gov.companieshouse.api.handler.delta.disqualification.request.PrivateCorporateDisqualificationUpsert;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.logging.Logger;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
 
 
 @ExtendWith(MockitoExtension.class)
 class ApiClientServiceImplTest {
 
+    private static final String DELTA_AT = "20240925171003950844";
+
     @Mock
     Logger logger;
 
+    @InjectMocks
     private ApiClientServiceImpl apiClientService;
-
-    @BeforeEach
-    void setup() {
-        apiClientService = new ApiClientServiceImpl(logger);
-        ReflectionTestUtils.setField(apiClientService, "chsApiKey", "apiKey");
-        ReflectionTestUtils.setField(apiClientService, "apiUrl", "https://api.companieshouse.gov.uk");
-    }
 
     @Test
     void putNaturalDisqualification() {
@@ -87,15 +82,12 @@ class ApiClientServiceImplTest {
                 anyString(),
                 any(PrivateDisqualificationDelete.class));
 
-        ApiResponse<Void> response = apiClientServiceSpy.deleteDisqualification("context_id",
-                "ZTgzYWQwODAzMGY1ZDNkNGZiOTAxOWQ1YzJkYzc5MWViMTE3ZjQxZA==");
-        verify(apiClientServiceSpy).executeOp(anyString(), eq("deleteDisqualification"),
-                eq("/disqualified-officers/delete/" +
-                        "ZTgzYWQwODAzMGY1ZDNkNGZiOTAxOWQ1YzJkYzc5MWViMTE3ZjQxZA==/internal"),
+        apiClientServiceSpy.deleteDisqualification(
+                "context_id", "officer_id", DELTA_AT);
+
+        verify(apiClientServiceSpy).executeOp(eq("context_id"), eq("deleteDisqualification"),
+                eq("/disqualified-officers/delete/officer_id/internal"),
                 any(PrivateDisqualificationDelete.class));
-
-        assertThat(response).isEqualTo(expectedResponse);
-
     }
 
 }


### PR DESCRIPTION
The consumer now sends a delta at, via the headers, to the API so a stale delete delta can be identified by the API. 

In addition, the delete delta flow now checks what kind of disqualified officers (natural or corporate) before sending that to the API.

[DSND-3119](https://companieshouse.atlassian.net/browse/DSND-3119)

[DSND-3119]: https://companieshouse.atlassian.net/browse/DSND-3119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ