### PR TITLE
DSND-2875: Change logging of officer_id 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
         <!-- Companies house specific dependencies -->
         <ch-kafka.version>3.0.3</ch-kafka.version>
-        <structured-logging.version>3.0.23</structured-logging.version>
+        <structured-logging.version>3.0.25</structured-logging.version>
         <kafka-models.version>3.0.8</kafka-models.version>
         <private-api-sdk-java.version>4.0.258</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.6</api-sdk-manager-java-library.version>

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalCorporateDisqualificationMapper.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalCorporateDisqualificationMapper.java
@@ -9,6 +9,7 @@ import uk.gov.companieshouse.api.disqualification.CorporateDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.DisqualificationLinks;
 import uk.gov.companieshouse.api.disqualification.InternalCorporateDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.InternalDisqualificationApiInternalData;
+import uk.gov.companieshouse.disqualifiedofficers.delta.logging.DataMapHolder;
 
 @Mapper(componentModel = "spring", uses = {DisqualificationMapper.class, 
         PermissionToActMapper.class})
@@ -36,6 +37,7 @@ public interface InternalCorporateDisqualificationMapper {
                                   DisqualificationOfficer sourceCase) {
         
         String encodedOfficerId = MapperUtils.encode(sourceCase.getOfficerId());
+        DataMapHolder.get().officerId(encodedOfficerId);
         String link = String.format("/disqualified-officers/corporate/%s", encodedOfficerId);
         CorporateDisqualificationApi externalTarget = target.getExternalData();
         InternalDisqualificationApiInternalData internalData = target.getInternalData();

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalNaturalDisqualificationMapper.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/InternalNaturalDisqualificationMapper.java
@@ -11,6 +11,7 @@ import uk.gov.companieshouse.api.disqualification.DisqualificationLinks;
 import uk.gov.companieshouse.api.disqualification.InternalDisqualificationApiInternalData;
 import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificationApi;
 import uk.gov.companieshouse.api.disqualification.NaturalDisqualificationApi;
+import uk.gov.companieshouse.disqualifiedofficers.delta.logging.DataMapHolder;
 
 @Mapper(componentModel = "spring", uses = {DisqualificationMapper.class, 
         PermissionToActMapper.class})
@@ -43,6 +44,7 @@ public interface InternalNaturalDisqualificationMapper {
                                   DisqualificationOfficer sourceCase) {
         
         String encodedOfficerId = MapperUtils.encode(sourceCase.getOfficerId());
+        DataMapHolder.get().officerId(encodedOfficerId);
         String link = String.format("/disqualified-officers/natural/%s", encodedOfficerId);
         NaturalDisqualificationApi externalTarget = target.getExternalData();
         InternalDisqualificationApiInternalData internalData = target.getInternalData();

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
@@ -110,12 +110,12 @@ public class DisqualifiedOfficersDeltaProcessor {
                     "Error deserialising disqualified-officers delete delta", ex);
         }
 
-        DataMapHolder.get().officerId(disqualifiedOfficersDelete.getOfficerId());
-        final String officerId = MapperUtils.encode(disqualifiedOfficersDelete.getOfficerId());
-        DataMapHolder.get().officerId(officerId);
+        DataMapHolder.get().officerIdRaw(disqualifiedOfficersDelete.getOfficerId());
+        final String encodedOfficerId = MapperUtils.encode(disqualifiedOfficersDelete.getOfficerId());
+        DataMapHolder.get().officerId(encodedOfficerId);
         apiClientService.deleteDisqualification(
                 contextId,
-                officerId,
+                encodedOfficerId,
                 disqualifiedOfficersDelete.getDeltaAt(),
                 DisqualificationType.getTypeFromCorporateInd(disqualifiedOfficersDelete.getCorporateInd()));
     }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
@@ -63,7 +63,6 @@ public class DisqualifiedOfficersDeltaProcessor {
         DisqualificationOfficer disqualificationOfficer = disqualifiedOfficersDelta
                 .getDisqualifiedOfficer()
                 .getFirst();
-        DataMapHolder.get().officerId(disqualificationOfficer.getOfficerId());
         if (disqualificationOfficer.getCorporateInd() != null
                 && disqualificationOfficer.getCorporateInd().equals("1")) {
             InternalCorporateDisqualificationApi apiObject;
@@ -76,6 +75,7 @@ public class DisqualifiedOfficersDeltaProcessor {
                 throw new NonRetryableErrorException(
                         "Error transforming delta to Corporate disqualification request", ex);
             }
+            DataMapHolder.get().officerId(apiObject.getInternalData().getOfficerId());
             invokeDataApiForCorporateDisqualification(contextId, apiObject);
         } else {
             InternalNaturalDisqualificationApi apiObject;
@@ -88,6 +88,7 @@ public class DisqualifiedOfficersDeltaProcessor {
                 throw new NonRetryableErrorException(
                         "Error transforming delta to Natural disqualification request", ex);
             }
+            DataMapHolder.get().officerId(apiObject.getInternalData().getOfficerId());
             invokeDataApiForNaturalDisqualification(contextId, apiObject);
         }
     }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/processor/DisqualifiedOfficersDeltaProcessor.java
@@ -63,6 +63,7 @@ public class DisqualifiedOfficersDeltaProcessor {
         DisqualificationOfficer disqualificationOfficer = disqualifiedOfficersDelta
                 .getDisqualifiedOfficer()
                 .getFirst();
+        DataMapHolder.get().officerIdRaw(disqualificationOfficer.getOfficerId());
         if (disqualificationOfficer.getCorporateInd() != null
                 && disqualificationOfficer.getCorporateInd().equals("1")) {
             InternalCorporateDisqualificationApi apiObject;
@@ -75,7 +76,6 @@ public class DisqualifiedOfficersDeltaProcessor {
                 throw new NonRetryableErrorException(
                         "Error transforming delta to Corporate disqualification request", ex);
             }
-            DataMapHolder.get().officerId(apiObject.getInternalData().getOfficerId());
             invokeDataApiForCorporateDisqualification(contextId, apiObject);
         } else {
             InternalNaturalDisqualificationApi apiObject;
@@ -88,7 +88,6 @@ public class DisqualifiedOfficersDeltaProcessor {
                 throw new NonRetryableErrorException(
                         "Error transforming delta to Natural disqualification request", ex);
             }
-            DataMapHolder.get().officerId(apiObject.getInternalData().getOfficerId());
             invokeDataApiForNaturalDisqualification(contextId, apiObject);
         }
     }
@@ -111,6 +110,7 @@ public class DisqualifiedOfficersDeltaProcessor {
                     "Error deserialising disqualified-officers delete delta", ex);
         }
 
+        DataMapHolder.get().officerId(disqualifiedOfficersDelete.getOfficerId());
         final String officerId = MapperUtils.encode(disqualifiedOfficersDelete.getOfficerId());
         DataMapHolder.get().officerId(officerId);
         apiClientService.deleteDisqualification(


### PR DESCRIPTION
Allow logging of officer_id within upsert deltas to use the encoded version for consistency with delete path.

Locally tested - encoded officer_id is seen across both delete and upsert paths. 

[DSND-2875](https://companieshouse.atlassian.net/browse/DSND-2875)

[DSND-2875]: https://companieshouse.atlassian.net/browse/DSND-2875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ