### PR TITLE
Fix regulation in disqualificationReference and update descriptionIdentifier wording map to match 16A wording 

### DIFF
--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/DisqualificationMapper.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/DisqualificationMapper.java
@@ -78,13 +78,11 @@ public interface DisqualificationMapper {
         reason.put("description_identifier", descriptionIdentifier.get(sectionParts[2]));
 
         String disqualificationReference = "article";
-        if (sectionParts[0].equals("CDDA") || sectionParts[0].equals("SAMLA")) {
+        if (sectionParts[0].equals("CDDA") || sectionParts[0].equals("SAMLA") || sectionParts[0].equals("CT-Regs")) {
             disqualificationReference = "section";
-        } else if (sectionParts[0].equals("CT-Regs")) {
-            disqualificationReference = "regulation";
         }
 
-        if (disqualificationReference == "regulation"){
+        if (sectionParts[0].equals("CT-Regs")){
             reason.put(disqualificationReference, sectionParts[2].substring(0));
         } else {
             reason.put(disqualificationReference, sectionParts[2].substring(1));

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/MapperUtils.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/mapper/MapperUtils.java
@@ -71,7 +71,7 @@ public final class MapperUtils {
         descriptionIdentifier.put("S9B", 
                 "competition-and-markets-authority-disqualification-undertaking");
         descriptionIdentifier.put("S10", "participation-in-wrongful-trading");
-        descriptionIdentifier.put("S3A", "director-disqualification-sanctions");
+        descriptionIdentifier.put("S3A", "disqualification-under-sanctions-regulation");
         descriptionIdentifier.put("16A", "disqualification-under-sanctions-regulation");
 
 


### PR DESCRIPTION
Fix the disqualificationReference to map to section instead of regulation 

Jira ticket: https://companieshouse.atlassian.net/browse/PAS-1126

Update the descriptionIdentifier to map S3A to the same wording as 16A

Jira ticket: https://companieshouse.atlassian.net/browse/PAS-1123