### PR TITLE
Feature/asm 1996 migrate to spring boot 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.12</version>
+        <version>2.1.14</version>
     </parent>
 
     <artifactId>disqualified-officers-delta-consumer</artifactId>
@@ -17,8 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>
-        <spring-boot-starter.version>3.5.14</spring-boot-starter.version>
-        <spring-context.version>6.2.18</spring-context.version>
+        <spring-boot-starter.version>4.0.6</spring-boot-starter.version>
         <map-struct.version>1.6.3</map-struct.version>
         <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>
@@ -27,14 +26,17 @@
         <tomcat-embed-core.version>11.0.22</tomcat-embed-core.version>
         <tomcat-embed-websocket.version>11.0.22</tomcat-embed-websocket.version>
         <kafka-clients.version>4.0.2</kafka-clients.version>
-        <opentelemetry-instrumentation-bom.version>2.16.0</opentelemetry-instrumentation-bom.version>
+        <opentelemetry-instrumentation-bom.version>2.24.0</opentelemetry-instrumentation-bom.version>
         <kotlin-lib.version>2.2.21</kotlin-lib.version>
         <io.grpc.version>1.80.0</io.grpc.version>
+
+        <!-- Transitive CVE pins -->
+        <jetty-bom.version>12.0.35</jetty-bom.version>
 
         <!-- Companies house specific dependencies -->
         <ch-kafka.version>3.0.6</ch-kafka.version>
         <structured-logging.version>3.0.49</structured-logging.version>
-        <kafka-models.version>3.0.18</kafka-models.version>
+        <kafka-models.version>3.0.22</kafka-models.version>
         <private-api-sdk-java.version>4.0.280</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.15</api-sdk-manager-java-library.version>
 
@@ -45,7 +47,7 @@
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
 
         <!-- Tests -->
-        <io-cucumber.version>7.9.0</io-cucumber.version>
+        <io-cucumber.version>7.34.3</io-cucumber.version>
         <skip.integration.tests>false</skip.integration.tests>
         <skip.unit.tests>false</skip.unit.tests>
         <assertj-core.version>3.27.7</assertj-core.version>
@@ -182,15 +184,30 @@
                 <version>${tomcat-embed-websocket.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.eclipse.jetty.ee10</groupId>
+                <artifactId>jetty-ee10-bom</artifactId>
+                <version>${jetty-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
 
+
         <dependency>
             <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>${spring-context.version}</version>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -236,13 +253,22 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-to-slf4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-json</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-jackson2</artifactId>
         </dependency>
 
         <dependency>
@@ -274,7 +300,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-aop</artifactId>
+            <artifactId>spring-boot-starter-aspectj</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>
@@ -398,9 +424,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
-            <version>${testcontainers.version}</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -443,6 +468,12 @@
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-spring</artifactId>
             <version>${io-cucumber.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <tomcat-embed-core.version>11.0.22</tomcat-embed-core.version>
         <tomcat-embed-websocket.version>11.0.22</tomcat-embed-websocket.version>
-        <kafka-clients.version>4.0.2</kafka-clients.version>
+        <kafka-clients.version>4.1.2</kafka-clients.version>
         <opentelemetry-instrumentation-bom.version>2.24.0</opentelemetry-instrumentation-bom.version>
         <kotlin-lib.version>2.2.21</kotlin-lib.version>
         <io.grpc.version>1.80.0</io.grpc.version>
@@ -192,11 +192,37 @@
                 <scope>import</scope>
             </dependency>
 
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>${kafka-clients.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
 
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>${wiremock.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.conscrypt</groupId>
+                    <artifactId>conscrypt-openjdk-uber</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.javacrumbs.json-unit</groupId>
+                    <artifactId>json-unit-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.ethlo.time</groupId>
+                    <artifactId>itu</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
@@ -420,6 +446,14 @@
                     <groupId>org.bitbucket.b_c</groupId>
                     <artifactId>jose4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.dynatrace.hash4j</groupId>
+                    <artifactId>hash4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>kafka-clients</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -432,13 +466,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>
-            <version>${testcontainers.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
@@ -459,7 +486,7 @@
 
         <dependency>
             <groupId>io.cucumber</groupId>
-            <artifactId>cucumber-junit</artifactId>
+            <artifactId>cucumber-junit-platform-engine</artifactId>
             <version>${io-cucumber.version}</version>
             <scope>test</scope>
         </dependency>
@@ -475,27 +502,6 @@
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-suite</artifactId>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.wiremock</groupId>
-            <artifactId>wiremock-standalone</artifactId>
-            <version>${wiremock.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.conscrypt</groupId>
-                    <artifactId>conscrypt-openjdk-uber</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>net.javacrumbs.json-unit</groupId>
-                    <artifactId>json-unit-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.ethlo.time</groupId>
-                    <artifactId>itu</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
     </dependencies>

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/AbstractIntegrationTest.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/AbstractIntegrationTest.java
@@ -10,7 +10,6 @@ import org.springframework.test.context.TestPropertySource;
 import uk.gov.companieshouse.disqualifiedofficers.delta.config.KafkaTestContainerConfig;
 import uk.gov.companieshouse.disqualifiedofficers.delta.steps.MessageProcessedEventListener;
 import org.testcontainers.kafka.ConfluentKafkaContainer;
-import org.springframework.beans.factory.annotation.Autowired;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import({KafkaTestContainerConfig.class, MessageProcessedEventListener.class})

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/AbstractIntegrationTest.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/AbstractIntegrationTest.java
@@ -2,14 +2,31 @@ package uk.gov.companieshouse.disqualifiedofficers.delta;
 
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+
 import uk.gov.companieshouse.disqualifiedofficers.delta.config.KafkaTestContainerConfig;
+import uk.gov.companieshouse.disqualifiedofficers.delta.steps.MessageProcessedEventListener;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@DirtiesContext
-@Import(KafkaTestContainerConfig.class)
+@Import({KafkaTestContainerConfig.class, MessageProcessedEventListener.class})
 @ActiveProfiles({"test"})
+@TestPropertySource(locations = {
+        "classpath:application.properties",
+        "classpath:itest.properties"
+})
 public abstract class AbstractIntegrationTest {
+    // ...existing code...
 
+    @DynamicPropertySource
+    static void registerKafkaProperties(DynamicPropertyRegistry registry) {
+        ConfluentKafkaContainer container = KafkaTestContainerConfig.getContainerInstance();
+        if (container != null) {
+            registry.add("spring.kafka.bootstrap-servers", container::getBootstrapServers);
+        }
+    }
 }

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/CucumberFeaturesRunnerITest.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/CucumberFeaturesRunnerITest.java
@@ -6,10 +6,10 @@ import io.cucumber.spring.CucumberContextConfiguration;
 import org.junit.runner.RunWith;
 
 
-//@RunWith(Cucumber.class)
-//@CucumberOptions(features = "src/itest/resources/features",
-//        plugin = {"pretty", "json:target/cucumber-report.json"})
-//@CucumberContextConfiguration
+@RunWith(Cucumber.class)
+@CucumberOptions(features = "src/itest/resources/features",
+        plugin = {"pretty", "json:target/cucumber-report.json"})
+@CucumberContextConfiguration
 public class CucumberFeaturesRunnerITest extends AbstractIntegrationTest {
 
 }

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/CucumberFeaturesRunnerITest.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/CucumberFeaturesRunnerITest.java
@@ -1,16 +1,20 @@
 package uk.gov.companieshouse.disqualifiedofficers.delta;
 
-import io.cucumber.junit.Cucumber;
-import io.cucumber.junit.CucumberOptions;
-import io.cucumber.spring.CucumberContextConfiguration;
-import org.junit.runner.RunWith;
+import io.cucumber.junit.platform.engine.Constants;
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
 
-
-@RunWith(Cucumber.class)
-@CucumberOptions(features = "src/itest/resources/features",
-        plugin = {"pretty", "json:target/cucumber-report.json"})
-@CucumberContextConfiguration
-public class CucumberFeaturesRunnerITest extends AbstractIntegrationTest {
-
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("features")
+@ConfigurationParameter(key = Constants.PLUGIN_PROPERTY_NAME,
+        value = "pretty, json:target/cucumber-report.json")
+// REMOVED @CucumberContextConfiguration — now on CucumberSpringConfig
+public class CucumberFeaturesRunnerITest {
+    // No longer extends AbstractIntegrationTest — the runner is not a Spring context
 }
+
+
 

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/CucumberFeaturesRunnerITest.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/CucumberFeaturesRunnerITest.java
@@ -5,10 +5,12 @@ import io.cucumber.junit.CucumberOptions;
 import io.cucumber.spring.CucumberContextConfiguration;
 import org.junit.runner.RunWith;
 
-@RunWith(Cucumber.class)
-@CucumberOptions(features = "src/itest/resources/features",
-        plugin = {"pretty", "json:target/cucumber-report.json"})
-@CucumberContextConfiguration
+
+//@RunWith(Cucumber.class)
+//@CucumberOptions(features = "src/itest/resources/features",
+//        plugin = {"pretty", "json:target/cucumber-report.json"})
+//@CucumberContextConfiguration
 public class CucumberFeaturesRunnerITest extends AbstractIntegrationTest {
 
 }
+

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/config/CucumberSpringConfig.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/config/CucumberSpringConfig.java
@@ -1,0 +1,20 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.config;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import io.cucumber.spring.CucumberContextConfiguration;
+import uk.gov.companieshouse.disqualifiedofficers.delta.steps.MessageProcessedEventListener;
+
+@CucumberContextConfiguration
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import({KafkaTestContainerConfig.class, MessageProcessedEventListener.class})
+@ActiveProfiles({"test"})
+@TestPropertySource(locations = {
+        "classpath:application.properties",
+        "classpath:itest.properties"
+})
+public class CucumberSpringConfig {
+}

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/config/KafkaTestContainerConfig.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/config/KafkaTestContainerConfig.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.disqualifiedofficers.delta.config;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -11,73 +10,86 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.testcontainers.kafka.ConfluentKafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 import uk.gov.companieshouse.delta.ChsDelta;
+import uk.gov.companieshouse.disqualifiedofficers.delta.consumer.MessageProcessedEvent;
 import uk.gov.companieshouse.disqualifiedofficers.delta.exception.RetryableTopicErrorInterceptor;
 import uk.gov.companieshouse.disqualifiedofficers.delta.serialization.ChsDeltaDeserializer;
 import uk.gov.companieshouse.disqualifiedofficers.delta.serialization.ChsDeltaSerializer;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.kafka.config.TopicBuilder;
 
 @TestConfiguration
+@EnableKafka
 public class KafkaTestContainerConfig {
 
     private final ChsDeltaDeserializer chsDeltaDeserializer;
     private final ChsDeltaSerializer chsDeltaSerializer;
 
+    private static ConfluentKafkaContainer containerInstance;
+
     @Autowired
-    public KafkaTestContainerConfig(ChsDeltaDeserializer chsDeltaDeserializer, ChsDeltaSerializer chsDeltaSerializer) {
+    public KafkaTestContainerConfig(ChsDeltaDeserializer chsDeltaDeserializer,
+                                    ChsDeltaSerializer chsDeltaSerializer) {
         this.chsDeltaDeserializer = chsDeltaDeserializer;
         this.chsDeltaSerializer = chsDeltaSerializer;
     }
 
     @Bean
     public ConfluentKafkaContainer kafkaContainer() {
-        ConfluentKafkaContainer kafkaContainer = new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest"));
-        kafkaContainer.start();
-        return kafkaContainer;
+        if (containerInstance == null) {
+            containerInstance = new ConfluentKafkaContainer(
+                    DockerImageName.parse("confluentinc/cp-kafka:7.4.0"));
+            containerInstance.start();
+        }
+        return containerInstance;
+    }
+
+    public static ConfluentKafkaContainer getContainerInstance() {
+        return containerInstance;
     }
 
     @Bean
-    ConcurrentKafkaListenerContainerFactory<String, ChsDelta> listenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, ChsDelta> factory =
-                new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(kafkaConsumerFactory());
-        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.RECORD);
-        return factory;
-    }
-
-    @Bean
-    public ConsumerFactory<String, ChsDelta> kafkaConsumerFactory() {
-        return new DefaultKafkaConsumerFactory<>(consumerConfigs(kafkaContainer()),
+    public ConsumerFactory<String, ChsDelta> kafkaConsumerFactory(
+            ConfluentKafkaContainer kafkaContainer) {
+        return new DefaultKafkaConsumerFactory<>(consumerConfigs(kafkaContainer),
                 new StringDeserializer(),
                 new ErrorHandlingDeserializer<>(chsDeltaDeserializer));
     }
 
     @Bean
-    public Map<String, Object> consumerConfigs(ConfluentKafkaContainer kafkaContainer) {
-        Map<String, Object> props = new HashMap<>();
-        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
-        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
-        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
-        props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class);
-        props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, ChsDeltaDeserializer.class);
-        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
-        props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
-        return props;
+    public ConcurrentKafkaListenerContainerFactory<String, ChsDelta> listenerContainerFactory(
+            ConfluentKafkaContainer kafkaContainer,
+            ApplicationEventPublisher eventPublisher) {
+        ConcurrentKafkaListenerContainerFactory<String, ChsDelta> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(kafkaConsumerFactory(kafkaContainer));
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.RECORD);
+        factory.setCommonErrorHandler(new DefaultErrorHandler((record, exception) ->
+                eventPublisher.publishEvent(
+                        new MessageProcessedEvent(record))));
+        return factory;
     }
 
     @Bean
-    public ProducerFactory<String, Object> producerFactory(ConfluentKafkaContainer kafkaContainer) {
+    public ProducerFactory<String, Object> producerFactory(
+            ConfluentKafkaContainer kafkaContainer) {
         Map<String, Object> props = new HashMap<>();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
@@ -89,14 +101,16 @@ public class KafkaTestContainerConfig {
     }
 
     @Bean
-    public KafkaTemplate<String, Object> kafkaTemplate() {
-        return new KafkaTemplate<>(producerFactory(kafkaContainer()));
+    public KafkaTemplate<String, Object> kafkaTemplate(
+            ConfluentKafkaContainer kafkaContainer) {
+        return new KafkaTemplate<>(producerFactory(kafkaContainer));
     }
 
     @Bean
-    public KafkaConsumer<String, Object> invalidTopicConsumer() {
+    public KafkaConsumer<String, Object> invalidTopicConsumer(
+            ConfluentKafkaContainer kafkaContainer) {
         Map<String, Object> props = new HashMap<>();
-        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer().getBootstrapServers());
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         props.put(ConsumerConfig.GROUP_ID_CONFIG, "disqualified-officer-delta-consumer");
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
@@ -104,12 +118,64 @@ public class KafkaTestContainerConfig {
         props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class);
         props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, StringDeserializer.class);
         props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
-        props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+        props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_uncommitted");
         KafkaConsumer<String, Object> consumer = new KafkaConsumer<>(props);
         consumer.subscribe(List.of("disqualified-officers-delta-invalid",
                 "disqualified-officers-delta-error", "disqualified-officers-delta-retry"));
-
         return consumer;
     }
 
+    @Bean
+    public AdminClient adminClient(ConfluentKafkaContainer kafkaContainer) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG,
+                kafkaContainer.getBootstrapServers());
+        return AdminClient.create(props);
+    }
+
+    @Bean
+    public NewTopic mainTopic() {
+        return TopicBuilder.name("disqualified-officers-delta")
+                .partitions(1)
+                .replicas(1)
+                .build();
+    }
+
+    @Bean
+    public NewTopic retryTopic() {
+        return TopicBuilder.name("disqualified-officers-delta-retry")
+                .partitions(1)
+                .replicas(1)
+                .build();
+    }
+
+    @Bean
+    public NewTopic errorTopic() {
+        return TopicBuilder.name("disqualified-officers-delta-error")
+                .partitions(1)
+                .replicas(1)
+                .build();
+    }
+
+    @Bean
+    public KafkaAdmin kafkaAdmin(ConfluentKafkaContainer kafkaContainer) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG,
+                kafkaContainer.getBootstrapServers());
+        return new KafkaAdmin(props);
+    }
+
+    // NOT a @Bean — plain private helper method
+    private Map<String, Object> consumerConfigs(ConfluentKafkaContainer kafkaContainer) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class);
+        props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, ChsDeltaDeserializer.class);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+        return props;
+    }
 }

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/config/WiremockPortInitializer.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/config/WiremockPortInitializer.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.config;
+
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+
+public class WiremockPortInitializer extends AbstractTestExecutionListener {
+    @Override
+    public void beforeTestClass(TestContext testContext) {
+        WiremockTestConfig.setupWiremock();
+        int wiremockPort = WiremockTestConfig.getPort();
+        System.setProperty("WIREMOCK_PORT", String.valueOf(wiremockPort));
+    }
+
+    @Override
+    public void afterTestClass(TestContext testContext) {
+        WiremockTestConfig.stopWiremock();
+    }
+}

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/config/WiremockTestConfig.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/config/WiremockTestConfig.java
@@ -1,0 +1,53 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.config;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WiremockTestConfig {
+
+    private static WireMockServer wireMockServer = null;
+
+    public static void setupWiremock() {
+        if (wireMockServer == null) {
+            wireMockServer = new WireMockServer(8888); // fixed port matching api.api-url
+        }
+        if (!wireMockServer.isRunning()) {
+            wireMockServer.start();
+            configureFor("localhost", 8888);
+        } else {
+            wireMockServer.resetAll();
+        }
+    }
+
+    public static int getPort() {
+        return wireMockServer != null ? wireMockServer.port() : -1;
+    }
+
+    public static void stopWiremock() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+            wireMockServer = null;
+        }
+    }
+
+    public static void stubKafkaApi(Integer responseCode) {
+        stubFor(
+                post(urlPathMatching("/private/resource-changed"))
+                        .willReturn(aResponse()
+                                .withStatus(responseCode)
+                                .withHeader("Content-Type", "application/json"))
+        );
+    }
+
+    public static List<ServeEvent> getServeEvents() {
+        return wireMockServer != null ? wireMockServer.getAllServeEvents() : new ArrayList<>();
+    }
+}

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
@@ -12,11 +12,11 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.tomakehurst.wiremock.WireMockServer;
-import io.cucumber.java.After;
-import io.cucumber.java.en.Given;
-import io.cucumber.java.en.Then;
-import io.cucumber.java.en.When;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -24,12 +24,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
+
+import io.cucumber.java.After;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 import uk.gov.companieshouse.delta.ChsDelta;
+import uk.gov.companieshouse.disqualifiedofficers.delta.config.WiremockTestConfig;
 import uk.gov.companieshouse.disqualifiedofficers.delta.data.TestData;
 import uk.gov.companieshouse.disqualifiedofficers.delta.matcher.DisqualificationRequestMatcher;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.StreamSupport;
 
 public class CommonSteps {
 
@@ -39,12 +42,12 @@ public class CommonSteps {
     @Value("${wiremock.server.port}")
     private String port;
 
-    private static WireMockServer wireMockServer;
-
     @Autowired
     private KafkaTemplate<String, Object> kafkaTemplate;
     @Autowired
     public KafkaConsumer<String, Object> kafkaConsumer;
+    @Autowired
+    private MessageProcessedEventListener messageProcessedEventListener;
 
     private String type;
     private String output;
@@ -52,6 +55,8 @@ public class CommonSteps {
     @Given("the application is running")
     public void theApplicationRunning() {
         assertThat(kafkaTemplate).isNotNull();
+        WiremockTestConfig.setupWiremock();
+        port = String.valueOf(WiremockTestConfig.getPort());
     }
 
     @When("^the consumer receives a (natural|corporate) disqualification of (undertaking|court order)$")
@@ -62,35 +67,35 @@ public class CommonSteps {
         this.output = TestData.getOutputData(officerType, disqType);
 
         ChsDelta delta = new ChsDelta(TestData.getInputData(officerType, disqType), 1, "1", false);
+        resetLatch();
         kafkaTemplate.send(mainTopic, delta);
-
         countDown();
     }
 
     @When("an invalid avro message is sent")
     public void invalidAvroMessageIsSent() throws Exception {
         kafkaTemplate.send(mainTopic, "InvalidData");
-
-        countDown();
+        // No latch — deserialization failure bypasses the listener entirely.
+        // Give the interceptor time to route to -invalid topic.
+        Thread.sleep(3000);
     }
 
     @When("a message with invalid data is sent")
     public void messageWithInvalidDataIsSent() throws Exception {
         ChsDelta delta = new ChsDelta("InvalidData", 1, "1", false);
+        resetLatch();
         kafkaTemplate.send(mainTopic, delta);
-
         countDown();
     }
 
     @When("^the consumer receives a message but the data api returns a (\\d*)$")
-    public void theConsumerReceivesMessageButDataApiReturns(int responseCode) throws Exception{
+    public void theConsumerReceivesMessageButDataApiReturns(int responseCode) throws Exception {
         configureWiremock();
         stubPutDisqualification("natural", responseCode);
-
         ChsDelta delta = new ChsDelta(
                 TestData.getInputData("natural", "undertaking"), 1, "1", false);
+        resetLatch();
         kafkaTemplate.send(mainTopic, delta);
-
         countDown();
     }
 
@@ -98,8 +103,8 @@ public class CommonSteps {
     public void theConsumerReceivesMessageThatCausesAnError() throws Exception {
         ChsDelta delta = new ChsDelta(
                 TestData.getInputData("natural", "error"), 1, "1", false);
+        resetLatch();
         kafkaTemplate.send(mainTopic, delta);
-
         countDown();
     }
 
@@ -111,21 +116,29 @@ public class CommonSteps {
     @Then("^the message should be moved to topic (.*)$")
     public void theMessageShouldBeMovedToTopic(String topic) {
         ConsumerRecord<String, Object> singleRecord = KafkaTestUtils.getSingleRecord(kafkaConsumer, topic);
-
         assertThat(singleRecord.value()).isNotNull();
     }
 
     @Then("^the message should retry (\\d*) times and then error$")
     public void theMessageShouldRetryAndError(int retries) {
-        ConsumerRecords<String, Object> records = KafkaTestUtils.getRecords(kafkaConsumer);
-        Iterable<ConsumerRecord<String, Object>> retryRecords =  records.records("disqualified-officers-delta-retry");
-        Iterable<ConsumerRecord<String, Object>> errorRecords =  records.records("disqualified-officers-delta-error");
+        List<ConsumerRecord<String, Object>> retryRecords = new ArrayList<>();
+        List<ConsumerRecord<String, Object>> errorRecords = new ArrayList<>();
 
-        int actualRetries = (int) StreamSupport.stream(retryRecords.spliterator(), false).count();
-        int errors = (int) StreamSupport.stream(errorRecords.spliterator(), false).count();
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (System.currentTimeMillis() < deadline) {
+            ConsumerRecords<String, Object> records = KafkaTestUtils.getRecords(
+                    kafkaConsumer, Duration.ofSeconds(2));
+            records.records("disqualified-officers-delta-retry")
+                    .forEach(retryRecords::add);
+            records.records("disqualified-officers-delta-error")
+                    .forEach(errorRecords::add);
+            if (retryRecords.size() >= retries && errorRecords.size() >= 1) {
+                break;
+            }
+        }
 
-        assertThat(actualRetries).isEqualTo(retries);
-        assertThat(errors).isEqualTo(1);
+        assertThat(retryRecords.size()).isEqualTo(retries);
+        assertThat(errorRecords.size()).isEqualTo(1);
     }
 
     @When("the consumer receives a delete payload")
@@ -133,8 +146,8 @@ public class CommonSteps {
         configureWiremock();
         stubDeleteDisqualification(200);
         ChsDelta delta = new ChsDelta(TestData.getDeleteData(), 1, "1", true);
+        resetLatch();
         kafkaTemplate.send(mainTopic, delta);
-
         countDown();
     }
 
@@ -142,18 +155,18 @@ public class CommonSteps {
     public void theConsumerReceivesInvalidDelete() throws Exception {
         configureWiremock();
         ChsDelta delta = new ChsDelta("invalid", 1, "1", true);
+        resetLatch();
         kafkaTemplate.send(mainTopic, delta);
-
         countDown();
     }
 
     @When("^the consumer receives a delete message but the data api returns a (\\d*)$")
-    public void theConsumerReceivesDeleteMessageButDataApiReturns(int responseCode) throws Exception{
+    public void theConsumerReceivesDeleteMessageButDataApiReturns(int responseCode) throws Exception {
         configureWiremock();
         stubDeleteDisqualification(responseCode);
         ChsDelta delta = new ChsDelta(TestData.getDeleteData(), 1, "1", true);
+        resetLatch();
         kafkaTemplate.send(mainTopic, delta);
-
         countDown();
     }
 
@@ -164,15 +177,24 @@ public class CommonSteps {
     }
 
     @After
-    public void shutdownWiremock(){
-        if (wireMockServer != null)
-            wireMockServer.stop();
+    public void shutdownWiremock() {
+        WiremockTestConfig.stopWiremock();
+    }
+
+    private void resetLatch() {
+        messageProcessedEventListener.reset();
+    }
+
+    private void countDown() throws InterruptedException {
+        boolean received = messageProcessedEventListener.getLatch().await(10, TimeUnit.SECONDS);
+        assertThat(received)
+                .as("Timed out waiting for Kafka message to be processed")
+                .isTrue();
     }
 
     private void configureWiremock() {
-        wireMockServer = new WireMockServer(Integer.parseInt(port));
-        wireMockServer.start();
-        configureFor("localhost", Integer.parseInt(port));
+        WiremockTestConfig.setupWiremock();
+        port = String.valueOf(WiremockTestConfig.getPort());
     }
 
     private void stubPutDisqualification(String type) {
@@ -188,10 +210,4 @@ public class CommonSteps {
         stubFor(delete(urlEqualTo("/disqualified-officers/natural/1kETe9SJWIp9OlvZgO1xmjyt5_s/internal"))
                 .willReturn(aResponse().withStatus(responseCode)));
     }
-
-    private void countDown() throws Exception {
-        CountDownLatch countDownLatch = new CountDownLatch(1);
-        countDownLatch.await(5, TimeUnit.SECONDS);
-    }
 }
-

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/CommonSteps.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.disqualifiedofficers.delta.steps;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.delete;
 import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
@@ -73,11 +72,10 @@ public class CommonSteps {
     }
 
     @When("an invalid avro message is sent")
-    public void invalidAvroMessageIsSent() throws Exception {
+    public void invalidAvroMessageIsSent() {
         kafkaTemplate.send(mainTopic, "InvalidData");
         // No latch — deserialization failure bypasses the listener entirely.
         // Give the interceptor time to route to -invalid topic.
-        Thread.sleep(3000);
     }
 
     @When("a message with invalid data is sent")
@@ -137,8 +135,8 @@ public class CommonSteps {
             }
         }
 
-        assertThat(retryRecords.size()).isEqualTo(retries);
-        assertThat(errorRecords.size()).isEqualTo(1);
+        assertThat(retryRecords).hasSize(retries);
+        assertThat(errorRecords).hasSize(1);
     }
 
     @When("the consumer receives a delete payload")

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/MessageProcessedEventListener.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/delta/steps/MessageProcessedEventListener.java
@@ -1,0 +1,26 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.steps;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.disqualifiedofficers.delta.consumer.MessageProcessedEvent;
+
+import java.util.concurrent.CountDownLatch;
+
+@Component
+public class MessageProcessedEventListener {
+
+    private CountDownLatch latch = new CountDownLatch(1);
+
+    @EventListener
+    public void onMessageProcessed(MessageProcessedEvent event) {
+        latch.countDown();
+    }
+
+    public void reset() {
+        latch = new CountDownLatch(1);
+    }
+
+    public CountDownLatch getLatch() {
+        return latch;
+    }
+}

--- a/src/itest/resources/itest.properties
+++ b/src/itest/resources/itest.properties
@@ -1,0 +1,1 @@
+disqualified-officers.delta.auto-create-topics=XXXX

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/config/KafkaConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/config/KafkaConfig.java
@@ -31,12 +31,8 @@ public class KafkaConfig {
 
     private final ChsDeltaDeserializer chsDeltaDeserializer;
     private final ChsDeltaSerializer chsDeltaSerializer;
-
     private final String bootstrapServers;
 
-    /**
-     * Constructor.
-     */
     public KafkaConfig(ChsDeltaDeserializer chsDeltaDeserializer,
                        ChsDeltaSerializer chsDeltaSerializer,
                        @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
@@ -45,18 +41,13 @@ public class KafkaConfig {
         this.bootstrapServers = bootstrapServers;
     }
 
-    /**
-     * Kafka Consumer Factory.
-     */
     @Bean
     public ConsumerFactory<String, ChsDelta> kafkaConsumerFactory() {
-        return new DefaultKafkaConsumerFactory<>(consumerConfigs(), new StringDeserializer(),
+        return new DefaultKafkaConsumerFactory<>(consumerConfigs(),
+                new StringDeserializer(),
                 new ErrorHandlingDeserializer<>(chsDeltaDeserializer));
     }
 
-    /**
-     * Kafka Producer Factory.
-     */
     @Bean
     public ProducerFactory<String, Object> producerFactory() {
         Map<String, Object> props = new HashMap<>();
@@ -74,22 +65,17 @@ public class KafkaConfig {
         return new KafkaTemplate<>(producerFactory());
     }
 
-    /**
-     * Kafka Listener Container Factory.
-     */
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, ChsDelta> listenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, ChsDelta> factory
-                = new ConcurrentKafkaListenerContainerFactory<>();
+        ConcurrentKafkaListenerContainerFactory<String, ChsDelta> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(kafkaConsumerFactory());
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.RECORD);
-
         return factory;
     }
 
     private Map<String, Object> consumerConfigs() {
         Map<String, Object> props = new HashMap<>();
-
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
@@ -98,7 +84,6 @@ public class KafkaConfig {
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
         props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
-
         return props;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/consumer/DisqualifiedOfficersDeltaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/consumer/DisqualifiedOfficersDeltaConsumer.java
@@ -9,7 +9,7 @@ import org.springframework.kafka.retrytopic.SameIntervalTopicReuseStrategy;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.retry.annotation.Backoff;
+import org.springframework.kafka.annotation.BackOff;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.delta.ChsDelta;
 import uk.gov.companieshouse.disqualifiedofficers.delta.exception.NonRetryableErrorException;
@@ -34,7 +34,7 @@ public class DisqualifiedOfficersDeltaConsumer {
      * Receives Main topic messages.
      */
     @RetryableTopic(attempts = "${disqualified-officers.delta.retry-attempts}",
-            backoff = @Backoff(delayExpression = "${disqualified-officers.delta.backoff-delay}"),
+            backOff = @BackOff(delayString = "${disqualified-officers.delta.backoff-delay}"),
             sameIntervalTopicReuseStrategy = SameIntervalTopicReuseStrategy.SINGLE_TOPIC,
             dltTopicSuffix = "-error",
             dltStrategy = DltStrategy.FAIL_ON_ERROR,

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/consumer/DisqualifiedOfficersDeltaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/consumer/DisqualifiedOfficersDeltaConsumer.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.disqualifiedofficers.delta.consumer;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.annotation.RetryableTopic;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -20,14 +21,18 @@ public class DisqualifiedOfficersDeltaConsumer {
 
     private final DisqualifiedOfficersDeltaProcessor deltaProcessor;
     public final KafkaTemplate<String, Object> kafkaTemplate;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * Default constructor.
      */
     @Autowired
-    public DisqualifiedOfficersDeltaConsumer(DisqualifiedOfficersDeltaProcessor deltaProcessor, KafkaTemplate<String, Object> kafkaTemplate) {
+    public DisqualifiedOfficersDeltaConsumer(DisqualifiedOfficersDeltaProcessor deltaProcessor,
+                                             KafkaTemplate<String, Object> kafkaTemplate,
+                                             ApplicationEventPublisher eventPublisher) {
         this.deltaProcessor = deltaProcessor;
         this.kafkaTemplate = kafkaTemplate;
+        this.eventPublisher = eventPublisher;
     }
 
     /**
@@ -45,10 +50,14 @@ public class DisqualifiedOfficersDeltaConsumer {
             containerFactory = "listenerContainerFactory")
     public void receiveMainMessages(Message<ChsDelta> chsDeltaMessage,
                                     @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
-        if (Boolean.TRUE.equals(chsDeltaMessage.getPayload().getIsDelete())) {
-            deltaProcessor.processDelete(chsDeltaMessage);
-        } else {
-            deltaProcessor.processDelta(chsDeltaMessage);
+        try{
+            if (Boolean.TRUE.equals(chsDeltaMessage.getPayload().getIsDelete())) {
+                deltaProcessor.processDelete(chsDeltaMessage);
+            } else {
+                deltaProcessor.processDelta(chsDeltaMessage);
+            }
+        } finally {
+            eventPublisher.publishEvent(new MessageProcessedEvent(this));
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/consumer/MessageProcessedEvent.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/delta/consumer/MessageProcessedEvent.java
@@ -1,0 +1,10 @@
+package uk.gov.companieshouse.disqualifiedofficers.delta.consumer;
+
+import org.springframework.context.ApplicationEvent;
+
+public class MessageProcessedEvent extends ApplicationEvent {
+
+    public MessageProcessedEvent(Object source) {
+        super(source);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/DisqualifiedOfficersDeltaConsumerApplicationIT.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/DisqualifiedOfficersDeltaConsumerApplicationIT.java
@@ -10,7 +10,7 @@ import static uk.gov.companieshouse.logging.util.LogContextProperties.REQUEST_ID
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/serialization/ChsDeltaSerializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/serialization/ChsDeltaSerializerTest.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.disqualifiedofficers.delta.serialization;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/BaseApiClientServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/service/api/BaseApiClientServiceImplTest.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.disqualifiedofficers.delta.service.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpHeaders;

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/transformer/DisqualifiedOfficersApiTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/delta/transformer/DisqualifiedOfficersApiTransformerTest.java
@@ -14,7 +14,7 @@ import uk.gov.companieshouse.api.disqualification.InternalNaturalDisqualificatio
 import uk.gov.companieshouse.disqualifiedofficers.delta.mapper.InternalCorporateDisqualificationMapper;
 import uk.gov.companieshouse.disqualifiedofficers.delta.mapper.InternalNaturalDisqualificationMapper;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import java.util.ArrayList;


### PR DESCRIPTION
Upgrading the service to Spring Boot 4 (without upgrading Jackson to v3). This PR is based on changes originally introduced in Ade’s PR:
https://github.com/companieshouse/disqualified-officers-delta-consumer/pull/94

That PR has since been closed as it became outdated, with some commits superseding Ade’s original changes.

This update also focuses on:

- Migrating integration tests to use Testcontainers for Kafka and WireMock for API mocking.
- Improving error handling and overall test reliability



[ASM-1996](https://companieshouse.atlassian.net/browse/ASM-1996)





[ASM-1996]: https://companieshouse.atlassian.net/browse/ASM-1996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ